### PR TITLE
docs: update lessons and slides for Rhiza v0.19.3

### DIFF
--- a/lessons/05-core-concepts.md
+++ b/lessons/05-core-concepts.md
@@ -25,7 +25,7 @@ Every downstream project has exactly one Rhiza config file. Here is what it look
 ```yaml
 # .rhiza/template.yml
 repository: Jebel-Quant/rhiza   # Which template repo to sync from
-ref: v0.18.8                     # Which version of the template to use
+ref: v0.19.3                     # Which version of the template to use
 
 profiles:                         # Curated bundle preset (recommended)
   - github-project
@@ -104,7 +104,7 @@ This loop runs automatically on a schedule (via a GitHub Actions workflow includ
 
 ## Version pinning and automated updates
 
-The `ref:` field in `template.yml` pins your project to a specific version of the template. When the template repo releases a new version, Renovate — a dependency automation tool — detects the new tag and opens a PR in your project that bumps `ref: v0.18.7` to `ref: v0.18.8`. You review and merge that PR, then the next sync picks up whatever changed in the new template version.
+The `ref:` field in `template.yml` pins your project to a specific version of the template. When the template repo releases a new version, Renovate — a dependency automation tool — detects the new tag and opens a PR in your project that bumps `ref: v0.19.2` to `ref: v0.19.3`. You review and merge that PR, then the next sync picks up whatever changed in the new template version.
 
 This gives you **opt-in updates**: the template can evolve quickly without forcing changes on you, but you can easily stay current with a single merge.
 

--- a/lessons/07-configuring-your-template.md
+++ b/lessons/07-configuring-your-template.md
@@ -9,7 +9,7 @@ The recommended approach is to use a **profile** — a curated preset that expan
 ```yaml
 # .rhiza/template.yml (profile-based — recommended)
 repository: Jebel-Quant/rhiza
-ref: v0.18.8
+ref: v0.19.3
 
 profiles:
   - github-project
@@ -24,7 +24,7 @@ For finer control, you can list bundles explicitly:
 ```yaml
 # .rhiza/template.yml (explicit bundles)
 repository: Jebel-Quant/rhiza
-ref: v0.18.8
+ref: v0.19.3
 
 templates:
   - core
@@ -54,12 +54,12 @@ This is the GitHub repository that Rhiza treats as your template source. It can 
 ## `ref`
 
 ```yaml
-ref: v0.18.8
+ref: v0.19.3
 ```
 
 This pins your project to a specific version of the template. It accepts:
 
-- **A tag** (e.g. `v0.18.8`) — recommended. Gives you a stable, known version. Renovate can detect new tags and open version-bump PRs automatically.
+- **A tag** (e.g. `v0.19.3`) — recommended. Gives you a stable, known version. Renovate can detect new tags and open version-bump PRs automatically.
 - **A branch** (e.g. `main`) — always fetches the latest commit on that branch. Useful during active development of a template, but means your project can receive breaking changes without a PR review step.
 
 For production projects, always pin to a tag.

--- a/lessons/08-the-sync-lifecycle.md
+++ b/lessons/08-the-sync-lifecycle.md
@@ -21,7 +21,7 @@ You can also trigger it manually from the GitHub Actions tab.
 
 **2. Renovate**
 
-Renovate watches the `ref: vX.Y.Z` line in your `.rhiza/template.yml`. When the template repository publishes a new tag, Renovate opens a PR that bumps your `ref` to the new version — for example, changing `ref: v0.18.7` to `ref: v0.18.8`.
+Renovate watches the `ref: vX.Y.Z` line in your `.rhiza/template.yml`. When the template repository publishes a new tag, Renovate opens a PR that bumps your `ref` to the new version — for example, changing `ref: v0.19.2` to `ref: v0.19.3`.
 
 These two PRs work together: Renovate bumps the version, the sync workflow applies what changed in that new version.
 

--- a/lessons/09-renovate.md
+++ b/lessons/09-renovate.md
@@ -4,7 +4,7 @@
 
 ## The problem Renovate solves for Rhiza
 
-Consider what happens after you run `uvx rhiza sync` for the first time with `ref: v0.18.8` pinned in your `template.yml`. Everything is wired up — CI, linting, releases. Six months later the template is at `v0.24.0` with security fixes, updated runner versions, and a new linting rule. Your project is still on `v0.18.8`.
+Consider what happens after you run `uvx rhiza sync` for the first time with `ref: v0.19.3` pinned in your `template.yml`. Everything is wired up — CI, linting, releases. Six months later the template is at `v0.24.0` with security fixes, updated runner versions, and a new linting rule. Your project is still on `v0.19.3`.
 
 Without Renovate, nothing happens. The template has moved, but your `ref:` is still pinned to the old version. You have to notice the new release yourself, manually update the file, re-run `uvx rhiza sync`, and open a PR. Across a handful of projects this is manageable. Across twenty or thirty it becomes the same problem Rhiza was built to solve in the first place: inconsistency through neglect.
 
@@ -15,10 +15,10 @@ Renovate closes this loop automatically. It opens a PR whenever a new template v
 Rhiza separates *knowing a new version exists* from *applying what changed in it*. Renovate handles the first part; the sync workflow handles the second.
 
 ```
-template repo publishes v0.18.8
+template repo publishes v0.19.3
          │
          ▼
-Renovate opens PR: ref: v0.18.7 → v0.18.8
+Renovate opens PR: ref: v0.19.2 → v0.19.3
          │
          ▼ (you review and merge)
 sync workflow triggers
@@ -34,7 +34,7 @@ The Renovate PR contains a single meaningful change: one line in `template.yml`.
 When a new template tag is published, Renovate opens a PR with a title like:
 
 ```
-Update dependency Jebel-Quant/rhiza to v0.18.8
+Update dependency Jebel-Quant/rhiza to v0.19.3
 ```
 
 The diff is minimal:
@@ -42,8 +42,8 @@ The diff is minimal:
 ```diff
 # .rhiza/template.yml
  repository: Jebel-Quant/rhiza
--ref: v0.18.7
-+ref: v0.18.8
+-ref: v0.19.2
++ref: v0.19.3
 ```
 
 The PR body includes a changelog summary (when the template repo provides one), a confidence indicator based on how many other repos have already merged this update, and links to the release notes.

--- a/lessons/slides/rhiza-deep-dive.html
+++ b/lessons/slides/rhiza-deep-dive.html
@@ -1229,7 +1229,7 @@ section.lead::before { display: none; }
 ;" data-marpit-pagination-total="45">
 <h2 id="the-config-file-rhizatemplateyml">The config file: <code>.rhiza/template.yml</code></h2>
 <pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-yaml"><span class="hljs-attr">repository:</span> <span class="hljs-string">Jebel-Quant/rhiza</span>   <span class="hljs-comment"># Which template repo to sync from</span>
-<span class="hljs-attr">ref:</span> <span class="hljs-string">v0.18.8</span>                     <span class="hljs-comment"># Which version (pinned tag — recommended)</span>
+<span class="hljs-attr">ref:</span> <span class="hljs-string">v0.19.3</span>                     <span class="hljs-comment"># Which version (pinned tag — recommended)</span>
 
 <span class="hljs-attr">profiles:</span>                         <span class="hljs-comment"># Curated bundle preset (recommended)</span>
   <span class="hljs-bullet">-</span> <span class="hljs-string">github-project</span>
@@ -1714,11 +1714,11 @@ section.lead::before { display: none; }
 <p>Without Renovate, the <code>ref:</code> pin is frozen. Projects drift behind the template silently.</p>
 <div style="display:flex;flex-direction:column;gap:0.45em;margin:0.9em 0;font-size:0.93em;">
   <div style="background:#eaf4fc;border-left:4px solid #2e86c1;border-radius:0 7px 7px 0;padding:0.6em 1.1em;">
-    template repo publishes <strong>v0.18.8</strong>
+    template repo publishes <strong>v0.19.3</strong>
   </div>
   <div style="padding-left:1.1em;color:#2e86c1;">↓</div>
   <div style="background:#eaf4fc;border-left:4px solid #2e86c1;border-radius:0 7px 7px 0;padding:0.6em 1.1em;">
-    Renovate opens PR: <code>ref: v0.18.7 → v0.18.8</code> &nbsp;<span style="color:#888;">(one line diff)</span>
+    Renovate opens PR: <code>ref: v0.19.2 → v0.19.3</code> &nbsp;<span style="color:#888;">(one line diff)</span>
   </div>
   <div style="padding-left:1.1em;color:#2e86c1;">↓ <span style="color:#888;font-size:0.88em;">you merge</span></div>
   <div style="background:#eaf4fc;border-left:4px solid #2e86c1;border-radius:0 7px 7px 0;padding:0.6em 1.1em;">
@@ -1798,14 +1798,14 @@ section::before {
 section.lead::before { display: none; }
 ;" data-marpit-pagination-total="45">
 <h2 id="the-ref-pin-in-depth">The <code>ref:</code> pin in depth</h2>
-<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-yaml"><span class="hljs-attr">ref:</span> <span class="hljs-string">v0.18.8</span>  <span class="hljs-comment"># pinned tag — recommended for all production repos</span>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-yaml"><span class="hljs-attr">ref:</span> <span class="hljs-string">v0.19.3</span>  <span class="hljs-comment"># pinned tag — recommended for all production repos</span>
 <span class="hljs-attr">ref:</span> <span class="hljs-string">main</span>     <span class="hljs-comment"># tracks latest commit — useful during template development only</span>
 </code></pre>
 <p><strong>Pinning to a tag gives you:</strong></p>
 <ul>
 <li>A known, auditable version — you can see exactly what each project is running</li>
 <li>Safe upgrades — Renovate proposes the bump, you review before it lands</li>
-<li>Easy rollback — if v0.18.8 breaks something, the cause is unambiguous</li>
+<li>Easy rollback — if v0.19.3 breaks something, the cause is unambiguous</li>
 </ul>
 <p><strong>Tracking <code>main</code></strong> delivers template changes immediately with no review step. Use only when actively developing the template. Never in repos others depend on.</p>
 <footer>Rhiza — The Living Template System · jebel-quant.github.io/rhiza-education · rhiza {{ rhiza_version }} / rhiza-cli {{ rhiza_cli_version }}</footer>
@@ -2040,7 +2040,7 @@ section.lead::before { display: none; }
 <h2 id="what-rhiza-init-asks">What <code>rhiza init</code> asks</h2>
 <p>Running <code>uvx rhiza init</code> walks you through three questions:</p>
 <pre is="marp-pre" data-auto-scaling="downscale-only"><code>? Template repository (GitHub owner/repo): Jebel-Quant/rhiza
-? Template ref (tag, branch, or commit):   v0.18.8
+? Template ref (tag, branch, or commit):   v0.19.3
 ? Profile or bundles to include:           github-project
 </code></pre>
 <p>The result is <code>.rhiza/template.yml</code> — one file, under version control, that describes everything Rhiza will manage in this project.</p>

--- a/lessons/slides/rhiza-intro.html
+++ b/lessons/slides/rhiza-intro.html
@@ -1041,7 +1041,7 @@ section.lead::before { display: none; }
 ;" data-marpit-pagination-total="28">
 <h2 id="the-config-file-rhizatemplateyml">The config file: <code>.rhiza/template.yml</code></h2>
 <pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-yaml"><span class="hljs-attr">repository:</span> <span class="hljs-string">Jebel-Quant/rhiza</span>   <span class="hljs-comment"># Which template repo to sync from</span>
-<span class="hljs-attr">ref:</span> <span class="hljs-string">v0.18.8</span>                     <span class="hljs-comment"># Which version (pinned tag — recommended)</span>
+<span class="hljs-attr">ref:</span> <span class="hljs-string">v0.19.3</span>                     <span class="hljs-comment"># Which version (pinned tag — recommended)</span>
 
 <span class="hljs-attr">profiles:</span>                         <span class="hljs-comment"># Curated bundle preset (recommended)</span>
   <span class="hljs-bullet">-</span> <span class="hljs-string">github-project</span>
@@ -1324,11 +1324,11 @@ section.lead::before { display: none; }
 <p>Without Renovate, the <code>ref:</code> pin is frozen. Projects drift behind the template silently.</p>
 <div style="display:flex;flex-direction:column;gap:0.45em;margin:0.9em 0;font-size:0.93em;">
   <div style="background:#eaf4fc;border-left:4px solid #2e86c1;border-radius:0 7px 7px 0;padding:0.6em 1.1em;">
-    template repo publishes <strong>v0.18.8</strong>
+    template repo publishes <strong>v0.19.3</strong>
   </div>
   <div style="padding-left:1.1em;color:#2e86c1;">↓</div>
   <div style="background:#eaf4fc;border-left:4px solid #2e86c1;border-radius:0 7px 7px 0;padding:0.6em 1.1em;">
-    Renovate opens PR: <code>ref: v0.18.7 → v0.18.8</code> &nbsp;<span style="color:#888;">(one line diff)</span>
+    Renovate opens PR: <code>ref: v0.19.2 → v0.19.3</code> &nbsp;<span style="color:#888;">(one line diff)</span>
   </div>
   <div style="padding-left:1.1em;color:#2e86c1;">↓ <span style="color:#888;font-size:0.88em;">you merge</span></div>
   <div style="background:#eaf4fc;border-left:4px solid #2e86c1;border-radius:0 7px 7px 0;padding:0.6em 1.1em;">

--- a/slides/rhiza-deep-dive.md
+++ b/slides/rhiza-deep-dive.md
@@ -229,7 +229,7 @@ The sync is not a bulldozer. It is a proposal.
 
 ```yaml
 repository: Jebel-Quant/rhiza   # Which template repo to sync from
-ref: v0.18.8                     # Which version (pinned tag — recommended)
+ref: v0.19.3                     # Which version (pinned tag — recommended)
 
 profiles:                         # Curated bundle preset (recommended)
   - github-project
@@ -331,11 +331,11 @@ Without Renovate, the `ref:` pin is frozen. Projects drift behind the template s
 
 <div style="display:flex;flex-direction:column;gap:0.45em;margin:0.9em 0;font-size:0.93em;">
   <div style="background:#eaf4fc;border-left:4px solid #2e86c1;border-radius:0 7px 7px 0;padding:0.6em 1.1em;">
-    template repo publishes <strong>v0.18.8</strong>
+    template repo publishes <strong>v0.19.3</strong>
   </div>
   <div style="padding-left:1.1em;color:#2e86c1;">↓</div>
   <div style="background:#eaf4fc;border-left:4px solid #2e86c1;border-radius:0 7px 7px 0;padding:0.6em 1.1em;">
-    Renovate opens PR: <code>ref: v0.18.7 → v0.18.8</code> &nbsp;<span style="color:#888;">(one line diff)</span>
+    Renovate opens PR: <code>ref: v0.19.2 → v0.19.3</code> &nbsp;<span style="color:#888;">(one line diff)</span>
   </div>
   <div style="padding-left:1.1em;color:#2e86c1;">↓ <span style="color:#888;font-size:0.88em;">you merge</span></div>
   <div style="background:#eaf4fc;border-left:4px solid #2e86c1;border-radius:0 7px 7px 0;padding:0.6em 1.1em;">
@@ -350,14 +350,14 @@ Two separate PRs: **should we upgrade?** then **here's what changed.**
 ## The `ref:` pin in depth
 
 ```yaml
-ref: v0.18.8  # pinned tag — recommended for all production repos
+ref: v0.19.3  # pinned tag — recommended for all production repos
 ref: main     # tracks latest commit — useful during template development only
 ```
 
 **Pinning to a tag gives you:**
 - A known, auditable version — you can see exactly what each project is running
 - Safe upgrades — Renovate proposes the bump, you review before it lands
-- Easy rollback — if v0.18.8 breaks something, the cause is unambiguous
+- Easy rollback — if v0.19.3 breaks something, the cause is unambiguous
 
 **Tracking `main`** delivers template changes immediately with no review step. Use only when actively developing the template. Never in repos others depend on.
 
@@ -396,7 +396,7 @@ Running `uvx rhiza init` walks you through three questions:
 
 ```
 ? Template repository (GitHub owner/repo): Jebel-Quant/rhiza
-? Template ref (tag, branch, or commit):   v0.18.8
+? Template ref (tag, branch, or commit):   v0.19.3
 ? Profile or bundles to include:           github-project
 ```
 

--- a/slides/rhiza-intro.md
+++ b/slides/rhiza-intro.md
@@ -196,7 +196,7 @@ The sync is not a bulldozer. It is a proposal.
 
 ```yaml
 repository: Jebel-Quant/rhiza   # Which template repo to sync from
-ref: v0.18.8                     # Which version (pinned tag — recommended)
+ref: v0.19.3                     # Which version (pinned tag — recommended)
 
 profiles:                         # Curated bundle preset (recommended)
   - github-project
@@ -257,11 +257,11 @@ Without Renovate, the `ref:` pin is frozen. Projects drift behind the template s
 
 <div style="display:flex;flex-direction:column;gap:0.45em;margin:0.9em 0;font-size:0.93em;">
   <div style="background:#eaf4fc;border-left:4px solid #2e86c1;border-radius:0 7px 7px 0;padding:0.6em 1.1em;">
-    template repo publishes <strong>v0.18.8</strong>
+    template repo publishes <strong>v0.19.3</strong>
   </div>
   <div style="padding-left:1.1em;color:#2e86c1;">↓</div>
   <div style="background:#eaf4fc;border-left:4px solid #2e86c1;border-radius:0 7px 7px 0;padding:0.6em 1.1em;">
-    Renovate opens PR: <code>ref: v0.18.7 → v0.18.8</code> &nbsp;<span style="color:#888;">(one line diff)</span>
+    Renovate opens PR: <code>ref: v0.19.2 → v0.19.3</code> &nbsp;<span style="color:#888;">(one line diff)</span>
   </div>
   <div style="padding-left:1.1em;color:#2e86c1;">↓ <span style="color:#888;font-size:0.88em;">you merge</span></div>
   <div style="background:#eaf4fc;border-left:4px solid #2e86c1;border-radius:0 7px 7px 0;padding:0.6em 1.1em;">


### PR DESCRIPTION
## Summary

Updates the curriculum to track the current upstream Rhiza release, **v0.19.3** (published 2026-06-16). Previously the lessons and slides referenced v0.18.8.

The changes from v0.18.8 → v0.19.3 upstream were almost entirely maintenance, security hardening, and CI (StepSecurity SHA-pinning, OSSF Scorecard, mutation testing, signed releases). The lessons already use the current `rhiza_*.yml` workflow names and `/rhiza` command, so no prose rewrites were needed — this is a version-tracking refresh.

## Changes

- Bump current `ref:` pins from `v0.18.8` → `v0.19.3` across lessons and slides
- Bump the "previous version" shown in Renovate diff/upgrade examples from `v0.18.7` → `v0.19.2`
- Rebuild committed HTML slides (`rhiza-intro`, `rhiza-deep-dive`) from the updated markdown sources — HTML diff is exclusively the version strings, no rendering churn

Left unchanged: historical/illustrative versions (`v0.8.0`, `v0.9.5`, `v0.0.1`) in the appendices/preamble, and the deliberately-hypothetical future `v0.24.0` in the Renovate lesson.

## Testing

- `pytest` (validates YAML/TOML code blocks in lessons): **34 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)