### PR TITLE
docs: drop stale generate-coverage-badge references

### DIFF
--- a/lessons/11-the-rhiza-ecosystem.md
+++ b/lessons/11-the-rhiza-ecosystem.md
@@ -48,7 +48,6 @@ These run locally on commit. The same checks also run in CI via the `rhiza_pre-c
 | `bump` | Bumps the version in `pyproject.toml` (major, minor, or patch) |
 | `release` | Pushes a version tag to trigger the release workflow |
 | `update-readme` | Refreshes the `make help` section in `README.md` |
-| `generate-coverage-badge` | Produces a coverage badge JSON file from pytest-cov output |
 | `version-matrix` | Reads `requires-python` from `pyproject.toml` and emits a JSON matrix for GitHub Actions |
 | `analyze-benchmarks` | Processes pytest-benchmark results and generates an interactive HTML report |
 

--- a/lessons/12-further-reading.md
+++ b/lessons/12-further-reading.md
@@ -64,7 +64,6 @@ Each command in [`rhiza-tools`](https://github.com/Jebel-Quant/rhiza-tools) has 
 | [bump.md](https://github.com/Jebel-Quant/rhiza-tools/blob/main/docs/commands/bump.md) | `rhiza-tools bump` | Semantic version bumping in `pyproject.toml` |
 | [release.md](https://github.com/Jebel-Quant/rhiza-tools/blob/main/docs/commands/release.md) | `rhiza-tools release` | Pushing a release tag to trigger the release workflow |
 | [version_matrix.md](https://github.com/Jebel-Quant/rhiza-tools/blob/main/docs/commands/version_matrix.md) | `rhiza-tools version-matrix` | Extracting Python versions from `pyproject.toml` for CI matrices |
-| [generate_coverage_badge.md](https://github.com/Jebel-Quant/rhiza-tools/blob/main/docs/commands/generate_coverage_badge.md) | `rhiza-tools generate-coverage-badge` | Producing a shields.io-compatible badge from coverage output |
 | [analyze_benchmarks.md](https://github.com/Jebel-Quant/rhiza-tools/blob/main/docs/commands/analyze_benchmarks.md) | `rhiza-tools analyze-benchmarks` | Processing pytest-benchmark results into an interactive HTML report |
 | [update_readme.md](https://github.com/Jebel-Quant/rhiza-tools/blob/main/docs/commands/update_readme.md) | `rhiza-tools update-readme` | Embedding `make help` output into `README.md` |
 | [rollback.md](https://github.com/Jebel-Quant/rhiza-tools/blob/main/docs/commands/rollback.md) | `rhiza-tools rollback` | Rolling back a release tag |

--- a/lessons/A2-projects-using-rhiza.md
+++ b/lessons/A2-projects-using-rhiza.md
@@ -22,7 +22,7 @@ The pre-commit hook repository. Because it is a Python package with its own CI a
 
 [github.com/Jebel-Quant/rhiza-tools](https://github.com/Jebel-Quant/rhiza-tools)
 
-The utility command package. Its CI pipeline uses `version-matrix` (from rhiza-tools) to generate the Python test matrix and `generate-coverage-badge` to publish the coverage badge — tools built by the project, consumed by its own CI, all wired together by the Rhiza template.
+The utility command package. Its CI pipeline uses `version-matrix` (from rhiza-tools) to generate the Python test matrix — a tool built by the project, consumed by its own CI, wired together by the Rhiza template.
 
 ## A real-world library: jquantstats
 

--- a/lessons/slides/rhiza-deep-dive.html
+++ b/lessons/slides/rhiza-deep-dive.html
@@ -3061,10 +3061,6 @@ section.lead::before { display: none; }
 <td>Reads <code>requires-python</code>, emits JSON matrix for GitHub Actions</td>
 </tr>
 <tr>
-<td><code>generate-coverage-badge</code></td>
-<td>Produces a shields.io badge from pytest-cov output</td>
-</tr>
-<tr>
 <td><code>analyze-benchmarks</code></td>
 <td>Converts pytest-benchmark results to an interactive HTML report</td>
 </tr>

--- a/slides/rhiza-deep-dive.md
+++ b/slides/rhiza-deep-dive.md
@@ -576,7 +576,6 @@ Runs on every `git commit`. The same checks run in CI via `rhiza_pre-commit.yml`
 | `bump patch / minor / major` | Increments version in `pyproject.toml` |
 | `release` | Creates and pushes a git tag → triggers `rhiza_release.yml` |
 | `version-matrix` | Reads `requires-python`, emits JSON matrix for GitHub Actions |
-| `generate-coverage-badge` | Produces a shields.io badge from pytest-cov output |
 | `analyze-benchmarks` | Converts pytest-benchmark results to an interactive HTML report |
 | `update-readme` | Embeds `make help` output into `README.md` |
 


### PR DESCRIPTION
Closes #30.

The rhiza-tools `generate-coverage-badge` command has **no caller in any Jebel-Quant repo** — coverage badges are produced by `genbadge[coverage]` (in rhiza's `book.mk`). The lessons/slides still described it as a live command; the `A2-projects-using-rhiza` lesson went further and wrongly claimed a project's **CI pipeline uses** it.

## Changes
- **lessons/A2-projects-using-rhiza.md** — drop the `generate-coverage-badge` clause from the CI description; keep `version-matrix` (genuinely CI-consumed).
- **slides/rhiza-deep-dive.md** & **lessons/11-the-rhiza-ecosystem.md** — remove the `generate-coverage-badge` row from the command tables.
- **lessons/12-further-reading.md** — remove the `generate_coverage_badge.md` doc link.
- **lessons/slides/rhiza-deep-dive.html** — remove the matching row from the built deck. This is a generated artifact (marp, via `slides/Makefile`); patched surgically to match its source so the diff stays reviewable. Running `make -C slides html` reproduces the same result.

## Related
- rhiza-tools#328 — the principle issue that lists `generate-coverage-badge` for deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)