### PR TITLE
docs: migrate curriculum to rhiza-claude ecosystem

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,12 +27,12 @@ jobs:
           RHIZA_VERSION=$(curl -sf https://api.github.com/repos/Jebel-Quant/rhiza/releases/latest \
             | python3 -c "import sys,json; print(json.load(sys.stdin).get('tag_name','unknown'))" \
             2>/dev/null || echo "unknown")
-          RHIZA_CLI_VERSION=$(curl -sf https://pypi.org/pypi/rhiza-cli/json \
-            | python3 -c "import sys,json; print(json.load(sys.stdin)['info'].get('version','unknown'))" \
+          RHIZA_CLAUDE_VERSION=$(curl -sf https://api.github.com/repos/Jebel-Quant/rhiza-claude/releases/latest \
+            | python3 -c "import sys,json; print(json.load(sys.stdin).get('tag_name','unknown'))" \
             2>/dev/null || echo "unknown")
           VERSION_FILES="mkdocs.yml slides/rhiza-intro.md slides/rhiza-deep-dive.md"
           sed -i "s/{{ rhiza_version }}/$RHIZA_VERSION/g" $VERSION_FILES
-          sed -i "s/{{ rhiza_cli_version }}/$RHIZA_CLI_VERSION/g" $VERSION_FILES
+          sed -i "s/{{ rhiza_claude_version }}/$RHIZA_CLAUDE_VERSION/g" $VERSION_FILES
 
       - name: Build slides
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: Fetch rhiza versions
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.11"
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Developers who are comfortable with Python, git, and basic CI/CD, and want to ad
 | 8 | [The Sync Lifecycle](lessons/08-the-sync-lifecycle.md) | How automated sync PRs work and how to review them |
 | 9 | [Renovate](lessons/09-renovate.md) | How Renovate keeps your `ref:` pin current and why it is essential at scale |
 | 10 | [Customising Safely](lessons/10-customizing-safely.md) | Extend Rhiza-managed projects without fighting the sync |
-| 11 | [The Rhiza Ecosystem](lessons/11-the-rhiza-ecosystem.md) | rhiza-cli, rhiza-hooks, rhiza-tools, rhiza-config, and rhiza-brainbug |
+| 11 | [The Rhiza Ecosystem](lessons/11-the-rhiza-ecosystem.md) | rhiza-claude, rhiza-hooks, and rhiza-brainbug |
 | 12 | [Further Reading](lessons/12-further-reading.md) | Direct links to every doc file across the Rhiza repos, organised by topic |
 
 Work through the lessons in order — each one builds on the last.

--- a/lessons/01-cicd-concepts.md
+++ b/lessons/01-cicd-concepts.md
@@ -71,7 +71,7 @@ on:
   workflow_dispatch:        # allows manual triggering from the GitHub UI
 ```
 
-Rhiza's CI workflow (`rhiza_ci.yml`) triggers on `push` and `pull_request`. The sync workflow (`rhiza_sync.yml`) uses `schedule`.
+Rhiza's CI workflow (`rhiza_ci.yml`) triggers on `push` and `pull_request`. The weekly maintenance workflow (`rhiza_weekly.yml`) uses `schedule`.
 
 ### Runners
 
@@ -120,7 +120,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 ```
 
-This runs three parallel jobs — one per Python version — and reports each as a separate check. Rhiza's `rhiza_ci.yml` builds this matrix dynamically from the `requires-python` field in `pyproject.toml` using `uvx rhiza-tools version-matrix`.
+This runs three parallel jobs — one per Python version — and reports each as a separate check. Rhiza's `rhiza_ci.yml` builds this matrix dynamically from the `requires-python` field in `pyproject.toml`. That derivation happens inside the reusable workflow itself — there is no command you run to generate it.
 
 ### Secrets and environment variables
 
@@ -133,7 +133,7 @@ Sensitive values (API tokens, passwords) are stored as *secrets* in the reposito
   run: uv publish
 ```
 
-Secrets are masked in logs — they never appear in plain text. Rhiza's release workflow uses `PYPI_TOKEN` for PyPI publishing on GitHub, and a `PAT_TOKEN` for the sync workflow (which needs permission to open pull requests).
+Secrets are masked in logs — they never appear in plain text. Rhiza's release workflow uses `PYPI_TOKEN` for PyPI publishing on GitHub, and any workflow that opens pull requests needs a token with permission to do so.
 
 ### Artifacts and Pages
 
@@ -156,7 +156,7 @@ permissions:
   contents: write      # create releases, push tags
   pages: write         # deploy to GitHub Pages
   id-token: write      # OIDC for PyPI Trusted Publishing
-  pull-requests: write # open sync PRs
+  pull-requests: write # open PRs
 ```
 
 Rhiza's templates set the minimal permissions needed for each workflow.
@@ -165,8 +165,8 @@ Rhiza's templates set the minimal permissions needed for each workflow.
 
 A typical Rhiza-managed project has this release flow:
 
-1. Developer runs `make bump` (calls `uvx rhiza-tools bump patch`) to increment the version in `pyproject.toml`.
-2. Developer runs `make release` (calls `uvx rhiza-tools release`) to create and push a git tag (e.g. `v1.2.3`).
+1. Developer runs `/rhiza:release` in Claude Code. It derives the next semantic version from the conventional commits since the last tag (via git-cliff), bumps the version in `pyproject.toml`, regenerates `CHANGELOG.md`, then commits and tags locally (e.g. `v1.2.3`). It stops before pushing.
+2. Developer pushes the tag (`git push --tags`).
 3. The tag push triggers the `rhiza_release.yml` workflow.
 4. The workflow builds a wheel, publishes to PyPI using OIDC Trusted Publishing (no token stored), and creates a GitHub Release.
 
@@ -178,14 +178,14 @@ Rhiza's template bundles wire all of this up so you do not have to:
 
 | Bundle | What it provides |
 |--------|-----------------|
-| `core` | Makefile with `make test`, `make lint`, `make bump`, `make release` |
-| `github` | All workflow files: CI, pre-commit, sync, release, Renovate |
+| `core` | Makefile with `make test`, `make lint`, and the rest of the local tooling |
+| `github` | Workflow files: CI, release, CodeQL, scorecard, and quality review |
 | `tests` | pytest config, coverage reporting, coverage badge publishing |
 | `book` | API documentation build and Pages deployment |
 | `marimo` | Notebook export and Pages deployment |
 | `devcontainer` | Ready-to-use development environment for VS Code / Codespaces |
 
-When you run `uvx rhiza sync`, you get a fully wired CI/CD pipeline committed to your repo. The rest of the curriculum explains how to configure, extend, and keep it up to date.
+When you bootstrap a project with `/rhiza:init` and keep it current with `/rhiza:update`, you get a fully wired CI/CD pipeline committed to your repo. The rest of the curriculum explains how to configure, extend, and keep it up to date.
 
 ---
 

--- a/lessons/02-uv-and-uvx.md
+++ b/lessons/02-uv-and-uvx.md
@@ -1,6 +1,6 @@
 # Lesson 2 — uv and uvx
 
-Rhiza is distributed as a `uvx` tool. Before you can run `uvx rhiza`, you need to understand what `uv` and `uvx` are and why the Rhiza ecosystem uses them.
+Rhiza-managed projects use `uv` as their package manager, and the `rhiza-claude` plugin lists `uv` among its prerequisites. Before you go further, you need to understand what `uv` and `uvx` are and why the Rhiza ecosystem relies on them.
 
 ## What is uv?
 
@@ -40,19 +40,19 @@ uv --version
 `uvx` is shorthand for `uv tool run`. It downloads a tool, runs it in an isolated throwaway environment, and discards the environment when done. You never need to install the tool globally or manage its dependencies.
 
 ```bash
-uvx rhiza init
+uvx ruff check .
 ```
 
 This is equivalent to:
 
 1. Create a temporary virtual environment
-2. Install `rhiza` and its dependencies into it
-3. Run `rhiza init`
+2. Install `ruff` and its dependencies into it
+3. Run `ruff check .`
 4. Delete the environment
 
 The first run fetches from PyPI and takes a few seconds. Subsequent runs use a local cache and are nearly instant.
 
-### Why not just `pip install rhiza`?
+### Why not just `pip install` the tool?
 
 Global installs cause dependency conflicts. If two tools you install globally need different versions of the same library, one of them breaks. `uvx` sidesteps this entirely by giving every tool its own isolated environment.
 
@@ -62,7 +62,7 @@ Global installs cause dependency conflicts. If two tools you install globally ne
 
 ## How the Rhiza ecosystem uses uv
 
-All Rhiza-managed projects adopt uv as the standard package manager. When you run `uvx rhiza sync`, one of the files it writes is `.python-version`, which tells uv which Python version the project targets. The Makefile it provides uses `uv sync` to set up the development environment.
+All Rhiza-managed projects adopt uv as the standard package manager. The template provides a `.python-version` file, which tells uv which Python version the project targets, and the Makefile it ships uses `uv sync` to set up the development environment. The `rhiza-claude` plugin also expects `uv` on your PATH.
 
 In CI, Rhiza's template workflows install uv with the official `astral-sh/setup-uv` action and then call `uv sync` or `uvx` — no manual pip steps required.
 
@@ -72,8 +72,8 @@ In CI, Rhiza's template workflows install uv with the official `astral-sh/setup-
 # Install uv
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# Run Rhiza without installing it
-uvx rhiza --help
+# Run a tool without installing it
+uvx ruff check .
 
 # Set up a project's development environment (inside a Rhiza-managed project)
 uv sync

--- a/lessons/05-core-concepts.md
+++ b/lessons/05-core-concepts.md
@@ -16,7 +16,7 @@ This is your actual project repo. It declares what it wants from the template re
 
 **3. The syncer**
 
-This is Rhiza itself — the `uvx rhiza` CLI tool. It reads the downstream project's config, fetches the specified files from the template repo at the specified version, and writes them into the project.
+This is the sync engine, driven by `/rhiza:update` from the `rhiza-claude` Claude Code plugin. It reads the downstream project's config (`.rhiza/template.yml`), fetches the specified files from the template repo at the specified version, writes them into the project, and records what it synced — repository, ref, commit SHA, timestamp, strategy, and file paths — in `.rhiza/template.lock`.
 
 ## The config file: `.rhiza/template.yml`
 
@@ -25,7 +25,7 @@ Every downstream project has exactly one Rhiza config file. Here is what it look
 ```yaml
 # .rhiza/template.yml
 repository: Jebel-Quant/rhiza   # Which template repo to sync from
-ref: v0.19.3                     # Which version of the template to use
+ref: v1.2.0                      # Which version of the template to use
 
 profiles:                         # Curated bundle preset (recommended)
   - github-project
@@ -85,7 +85,7 @@ Listing every file path in `include` by hand gets tedious. Rhiza provides **bund
 | `gitlab-project` | `core`, `gitlab`, `tests`, `gitlab-tests`, `renovate` |
 | `local` | `core` only (no CI/CD) |
 
-Run `make explain-bundles` in any Rhiza-managed project to see the full list with dependency information. The `core` bundle is required. All others are optional.
+Browse the `bundles/` directory in the template repo to see the full list with dependency information. The `core` bundle is required. All others are optional.
 
 ## The sync loop
 
@@ -97,16 +97,16 @@ fetch → diff → review → commit
 
 1. **Fetch**: Rhiza reads your `template.yml` and pulls the matching files from the template repo at the specified `ref`.
 2. **Diff**: It compares what it fetched against what is currently in your project.
-3. **Review**: If anything changed, a pull request is opened with the diff (in automated mode) or the changes are written to disk (in manual mode).
+3. **Review**: If anything changed, a pull request is opened with the diff and a quality scorecard.
 4. **Commit**: You review the PR and merge it — or reject it if the change doesn't apply to your project.
 
-This loop runs automatically on a schedule (via a GitHub Actions workflow included in the `github` bundle). You can also trigger it manually with `make sync` or `uvx rhiza sync`.
+This loop is human-initiated. You run `/rhiza:update` in Claude Code, which bumps the `ref` to the latest release, materializes the changed files, resolves conflicts against the template, runs the quality gates, and opens the PR for you to review. There is no longer an automated CI workflow that materializes template files — a person drives every update.
 
 ## Version pinning and automated updates
 
-The `ref:` field in `template.yml` pins your project to a specific version of the template. When the template repo releases a new version, Renovate — a dependency automation tool — detects the new tag and opens a PR in your project that bumps `ref: v0.19.2` to `ref: v0.19.3`. You review and merge that PR, then the next sync picks up whatever changed in the new template version.
+The `ref:` field in `template.yml` pins your project to a specific version of the template. When the template repo releases a new version, Renovate — a dependency automation tool — detects the new tag and opens a PR in your project that bumps `ref: v1.1.0` to `ref: v1.2.0`. That PR is a *notification* that a newer template exists; merging it no longer triggers a sync on its own. To actually apply the new version, run `/rhiza:update`, which bumps the `ref` and syncs the files in a single reviewable PR.
 
-This gives you **opt-in updates**: the template can evolve quickly without forcing changes on you, but you can easily stay current with a single merge.
+This gives you **opt-in updates**: the template can evolve quickly without forcing changes on you, but you can easily stay current when you choose to.
 
 ---
 

--- a/lessons/06-getting-started.md
+++ b/lessons/06-getting-started.md
@@ -6,32 +6,50 @@ This lesson walks you through setting up Rhiza in a new project from scratch.
 
 You need:
 
-- **[uv](https://docs.astral.sh/uv/)** — Rhiza is distributed as a `uvx` tool. Install it with:
+- **[uv](https://docs.astral.sh/uv/)** — Rhiza's bundled scripts run on `uv`, and `/rhiza:init` uses it to scaffold the project. Install it with:
   ```bash
   curl -LsSf https://astral.sh/uv/install.sh | sh
   ```
-- **A GitHub account** with access to the template repository (`Jebel-Quant/rhiza` or your org's fork).
-- **A new project repo** — an empty git repository on GitHub where you want Rhiza's config to land.
+- **[Claude Code](https://docs.claude.com/en/docs/claude-code)** — Rhiza is driven from Claude Code via the `rhiza` plugin. This is the primary interface.
+- **A GitHub account** with access to the template repository (`Jebel-Quant/rhiza` or your org's fork). Rhiza also supports GitLab.
+- **A project directory** — a new or empty folder where you want Rhiza's config to land. `/rhiza:init` will run `git init` for you if the folder is not a repo yet.
 
-## Step 1: Initialise Rhiza in your project
+## Step 1: Install the Rhiza plugin
 
-Navigate to your project directory and run:
+Rhiza ships as a Claude Code plugin from the `rhiza-claude` marketplace. Inside Claude Code, add the marketplace and install the plugin once:
 
-```bash
-uvx rhiza init
+```
+/plugin marketplace add Jebel-Quant/rhiza-claude
+/plugin install rhiza@rhiza-claude
 ```
 
-Rhiza will ask you a few questions:
+To pin a specific version, append a git tag when you add the marketplace:
 
-- Which template repository to use (default: `Jebel-Quant/rhiza`)
-- Which version (ref) to pin to
-- Which bundles you want
+```
+/plugin marketplace add Jebel-Quant/rhiza-claude#v0.4.1
+```
 
-After you answer, it writes `.rhiza/template.yml` to your project. This is the only Rhiza config file your project needs.
+The plugin's bundled scripts are stdlib-only Python — there is no separate `rhiza` CLI to install. Everything you need beyond `uv`, `git`, and `make` comes from the plugin.
 
-> **Note:** `uvx rhiza init` does not write any template files yet. It only creates the config that tells Rhiza what to fetch. The next step does the actual fetching.
+Once installed, you have the full `/rhiza:*` command set available. The two commands you will use to get running are `/rhiza:init` (first-time bootstrap) and `/rhiza:update` (later template updates).
 
-## Step 2: Choose your bundles or profile
+## Step 2: Bootstrap your project
+
+Navigate to your project directory and, in Claude Code, run:
+
+```
+/rhiza:init
+```
+
+`/rhiza:init` bootstraps a rhiza-managed repo in the current folder. It will ask you a few questions:
+
+- **GitHub or GitLab** (it auto-detects an existing remote if there is one)
+- **Owner, name, and visibility** for the repo
+- **Language and template repository** — Python (default, `Jebel-Quant/rhiza`) or Go (`Jebel-Quant/rhiza-go`)
+
+For a new Python project, it then scaffolds the standard skeleton — `pyproject.toml`, `src/<pkg>/`, `tests/`, a starter module and test, and optionally `mkdocs.yml` and a README — and writes `.rhiza/template.yml`, the single Rhiza config file your project needs.
+
+## Step 3: Choose your bundles or profile
 
 During `init`, you will be asked what to include. For most projects, choose the `github-project` profile — it expands to `core`, `github`, `tests`, `github-tests`, and `renovate`, which covers CI/CD, testing, and automated dependency updates in one step.
 
@@ -43,28 +61,18 @@ If you prefer to select bundles individually, the essentials are:
 - `github-tests` (testing and security scan workflows on GitHub)
 - `renovate` (automated dependency updates)
 
-You can add more bundles later by editing `template.yml` and re-running `sync`. To see every available bundle with descriptions and dependency information, run:
+You can add more bundles later by editing `template.yml` and running `/rhiza:update`. To see every available bundle with its description and dependencies, browse the template repo's [`bundles/` directory](https://github.com/Jebel-Quant/rhiza/tree/main/bundles).
 
-```bash
-make explain-bundles
-```
+## Step 4: The first sync and its PR
 
-## Step 3: Sync
+`/rhiza:init` does the first template sync for you. It reads your `.rhiza/template.yml`, fetches all matching files from the template repository, writes them into your project, validates the config, and runs the test suite.
 
-Now fetch and apply the template files:
+Crucially, it does **not** push these changes to your default branch. Instead it puts the scaffold and first sync on a `rhiza_init_<date>` branch and opens a pull request. This gives you a review step before any Rhiza-managed files land on `main`.
 
-```bash
-uvx rhiza sync
-```
-
-Rhiza reads your `.rhiza/template.yml`, fetches all matching files from the template repository, and writes them into your project.
-
-This will create files like:
+The PR will introduce files like:
 
 ```
 .github/workflows/rhiza_ci.yml
-.github/workflows/rhiza_pre-commit.yml
-.github/workflows/rhiza_sync.yml
 .pre-commit-config.yaml
 ruff.toml
 Makefile
@@ -72,24 +80,20 @@ Makefile
 .editorconfig
 ```
 
-Review the changes with `git diff --stat`, then commit them:
+Review the PR diff, then merge it when you are happy.
 
-```bash
-git add .
-git commit -m "chore: initialise rhiza template"
+## Step 5: Verify your setup
+
+To check what Rhiza synced and confirm your configuration, use the plugin's read-only utilities in Claude Code:
+
+```
+/rhiza:status
+/rhiza:validate
 ```
 
-## Step 4: Verify your setup
+`/rhiza:status` shows the template repository, pinned `ref`, the synced commit SHA, the sync timestamp, and the files that were materialized (it reads `.rhiza/template.lock`). `/rhiza:validate` confirms your `.rhiza/template.yml` parses and its fields are well-typed. Start here whenever something seems wrong.
 
-Run `make doctor` to check that your project and environment are correctly configured:
-
-```bash
-make doctor
-```
-
-This validates required tools, Python version consistency across `.python-version`, `pyproject.toml`, and the CI matrix, and the `.rhiza/` configuration. Start here whenever something seems wrong.
-
-Run `make help` to see all the Makefile targets now available. You should see targets grouped by category: testing, quality, docs, releasing, and more.
+Run `make help` to see all the Makefile targets now available — grouped by category: testing, quality, docs, releasing, and more.
 
 Run `make install` to set up your development environment:
 
@@ -99,6 +103,16 @@ make install
 
 This installs your project dependencies, sets up pre-commit hooks, and gets you ready to work.
 
+## Applying later template updates
+
+`/rhiza:init` is a one-time bootstrap. Once your repo is rhiza-managed, you pull in new template versions with:
+
+```
+/rhiza:update
+```
+
+`/rhiza:update` bumps your `ref:` to the latest rhiza release, syncs the changed template files, resolves conflicts against the template upstream, runs the quality gates, and opens a PR with a quality scorecard. This is the mechanism described in Lesson 8 — it replaces any older `sync` command.
+
 ## What you just got
 
 Your project now has:
@@ -106,9 +120,9 @@ Your project now has:
 - **CI/CD workflows** that run on push and pull requests — automatically testing your code across multiple Python versions.
 - **A modular Makefile** with targets for testing, linting, releasing, and more.
 - **Pre-commit hooks** that enforce code quality on every commit.
-- **A sync workflow** (`rhiza_sync.yml`) that runs on a schedule and opens PRs when the template is updated.
+- **A living-template link** to the upstream, kept current by running `/rhiza:update` when a new template version ships.
 
-None of this required manual configuration. It came from the template, and it will stay up to date via the sync mechanism described in Lesson 8.
+None of this required manual configuration. It came from the template, and it stays up to date via the update mechanism described in Lesson 8.
 
 ---
 

--- a/lessons/07-configuring-your-template.md
+++ b/lessons/07-configuring-your-template.md
@@ -9,7 +9,7 @@ The recommended approach is to use a **profile** — a curated preset that expan
 ```yaml
 # .rhiza/template.yml (profile-based — recommended)
 repository: Jebel-Quant/rhiza
-ref: v0.19.3
+ref: v1.2.0
 
 profiles:
   - github-project
@@ -24,7 +24,7 @@ For finer control, you can list bundles explicitly:
 ```yaml
 # .rhiza/template.yml (explicit bundles)
 repository: Jebel-Quant/rhiza
-ref: v0.19.3
+ref: v1.2.0
 
 templates:
   - core
@@ -54,12 +54,12 @@ This is the GitHub repository that Rhiza treats as your template source. It can 
 ## `ref`
 
 ```yaml
-ref: v0.19.3
+ref: v1.2.0
 ```
 
 This pins your project to a specific version of the template. It accepts:
 
-- **A tag** (e.g. `v0.19.3`) — recommended. Gives you a stable, known version. Renovate can detect new tags and open version-bump PRs automatically.
+- **A tag** (e.g. `v1.2.0`) — recommended. Gives you a stable, known version. Renovate can detect new releases and open version-bump PRs automatically.
 - **A branch** (e.g. `main`) — always fetches the latest commit on that branch. Useful during active development of a template, but means your project can receive breaking changes without a PR review step.
 
 For production projects, always pin to a tag.
@@ -95,7 +95,7 @@ templates:
 
 Bundles come in two kinds. **Feature bundles** contain local tooling only (`core`, `tests`, `book`, `marimo`, etc.). **Platform overlay bundles** layer CI/CD workflows on top (`github-tests`, `github-book`, `gitlab-tests`, etc.). When you want CI for a feature, you need both: for example, `tests` (pytest config) plus `github-tests` (the GitHub Actions workflow that runs it).
 
-Run `make explain-bundles` to see every available bundle with its description and dependencies.
+Browse the template repo's [`bundles/` directory](https://github.com/Jebel-Quant/rhiza/tree/main/bundles) to see every available bundle with its description and dependencies.
 
 ## `include` — explicit file patterns
 
@@ -124,7 +124,7 @@ exclude: |
   .env
 ```
 
-This is how you customise a file that Rhiza would otherwise manage. Add it to `exclude`, make your local edits, and the sync will skip it.
+This is how you customise a file that Rhiza would otherwise manage. Add it to `exclude`, make your local edits, and the next update will skip it.
 
 > **Warning:** Be deliberate about what you put in `exclude`. Files you exclude will not receive upstream template updates. If the template fixes a security issue in a workflow you have excluded, you will not get that fix automatically.
 
@@ -144,17 +144,17 @@ For most projects, start with the `github-project` or `gitlab-project` profile a
 | Git LFS support | `+ lfs` |
 | Performance benchmarks | `+ benchmarks` |
 
-When in doubt, start with `profiles: [github-project]`. You can always add bundles later — add them to `templates:` and re-run `uvx rhiza sync`.
+When in doubt, start with `profiles: [github-project]`. You can always add bundles later — add them to `templates:` and run `/rhiza:update`.
 
 ## Updating the config
 
-After editing `template.yml`, always re-run:
+After editing `template.yml`, always run:
 
-```bash
-uvx rhiza sync
+```
+/rhiza:update
 ```
 
-This applies any changes — new bundles, updated include/exclude patterns, or a new `ref` — to your project.
+This applies any changes — new bundles, updated include/exclude patterns, or a new `ref` — to your project, and opens a PR with a quality scorecard for review.
 
 ---
 

--- a/lessons/08-the-sync-lifecycle.md
+++ b/lessons/08-the-sync-lifecycle.md
@@ -1,45 +1,44 @@
 # Lesson 8 — The Sync Lifecycle
 
-Once Rhiza is set up, you largely stop thinking about it — until a sync PR appears. This lesson explains what drives those PRs, what they contain, and how to handle them.
+Once Rhiza is set up, you largely stop thinking about it — until it is time to pull in a new template version. This lesson explains what drives an update, what the resulting PR contains, and how to handle it.
 
-## Two triggers for sync
+## How updates reach your project
 
-Your project will receive sync-related PRs from two sources:
+There is no automated CI job that materialises template files into your repo. Template file changes are applied by a human running `/rhiza:update` in Claude Code. What you receive automatically is a *signal* that a new template version exists — and there are two ways that signal arrives.
 
-**1. The sync workflow (`rhiza_sync.yml`)**
+**1. You run `/rhiza:update` yourself**
 
-This GitHub Actions workflow runs on a schedule (typically weekly) and does the following:
+`/rhiza:update` is the update mechanism. When you run it in Claude Code, it:
 
-1. Runs `uvx rhiza sync` inside a temporary branch.
-2. Compares the result against your current `main` branch.
-3. If any files changed, opens a pull request with the diff.
-4. If nothing changed, exits silently.
+1. Bumps your `ref:` to the latest (or a given) rhiza release.
+2. Materialises the changed template files into your repo.
+3. Resolves conflicts against the template upstream.
+4. Runs the quality gates and produces a scorecard.
+5. Opens a pull request with the file changes and that quality scorecard.
 
-You can also trigger it manually from the GitHub Actions tab.
+You can run it whenever you like. To check first whether you are behind the latest release, run `/rhiza:status --check` — it compares your pinned `ref:` against the latest upstream release.
 
-> **Note:** The sync workflow falls back to the built-in `GITHUB_TOKEN` if no `PAT_TOKEN` secret is set, and this is enough to open PRs for most file types. However, if the sync includes changes to files under `.github/workflows/`, GitHub requires a Personal Access Token — the default `GITHUB_TOKEN` cannot write workflow files. If your project uses the `github` bundle (which includes workflow files), set a `PAT_TOKEN` secret in your repository to avoid silent failures.
+**2. Renovate opens a `ref:` bump PR**
 
-**2. Renovate**
+Renovate watches the `ref: vX.Y.Z` line in your `.rhiza/template.yml`. When the template repository publishes a new release, Renovate opens a PR that bumps your `ref` to the new version — for example, changing `ref: v1.1.0` to `ref: v1.2.0`.
 
-Renovate watches the `ref: vX.Y.Z` line in your `.rhiza/template.yml`. When the template repository publishes a new tag, Renovate opens a PR that bumps your `ref` to the new version — for example, changing `ref: v0.19.2` to `ref: v0.19.3`.
+This PR is a **notification only**. Merging it changes one line in `template.yml`, but it does *not* apply the new template files — there is no sync workflow to do that. Treat the Renovate PR as a prompt: a new template version is available. When you are ready to adopt it, run `/rhiza:update`, which bumps the ref and materialises the changed files together in a single reviewable PR.
 
-These two PRs work together: Renovate bumps the version, the sync workflow applies what changed in that new version.
+## Reading a `/rhiza:update` PR
 
-## Reading a sync PR
-
-A sync PR shows you a standard git diff of the template files that changed. Here is how to read it:
+A `/rhiza:update` PR shows you a standard git diff of the template files that changed, plus a quality scorecard summarising the state of the repo after the update. Here is how to read the diff:
 
 - **Added lines (green)**: New content in the template that your project does not have yet. Usually safe to accept.
 - **Removed lines (red)**: Content removed from the template. Check whether you depend on anything being removed.
 - **Changed lines**: Modifications to existing files. Read these carefully — they may update a workflow version, change a lint rule, or fix a bug.
 
-The PR description usually explains what changed at a high level. If you pinned to a tag and Renovate bumped it, check the template repo's changelog for the version you are upgrading to.
+The scorecard tells you whether the update leaves your repo passing the quality gates (lint, types, docs, deps, security, tests, test-layout, complexity, architecture). If you bumped across several versions, check the template repo's changelog for the versions you are upgrading through.
 
 ## When to accept, modify, or reject
 
 **Accept the PR as-is** when:
 - The changes are CI workflow updates, runner version bumps, or linting rule adjustments that apply cleanly to your project.
-- The diff looks correct and your tests pass in the PR branch.
+- The diff looks correct, the scorecard is healthy, and your tests pass in the PR branch.
 
 **Modify the PR before merging** when:
 - A change applies to your project but needs a small adjustment (e.g. the template added a workflow that references a file your project names differently).
@@ -49,31 +48,27 @@ The PR description usually explains what changed at a high level. If you pinned 
 - The change is not relevant to your project (e.g. the template added Docker support but your project will never use containers).
 - You have intentionally diverged from the template for a file and want to keep your local version.
 
-> **Note:** Closing a sync PR is fine. The next scheduled sync will open a new PR if the template still differs from your project. If you want to permanently silence a specific file from sync, add it to `exclude:` in `template.yml`.
+> **Note:** Closing an update PR is fine — nothing changes until you merge. When you next run `/rhiza:update`, it will produce a fresh PR against the current template. If you want to permanently silence a specific file from updates, add it to `exclude:` in `template.yml`.
 
 ## Handling conflicts
 
-Occasionally a sync PR will have a merge conflict — usually because you edited a template-managed file locally. Your options:
+Occasionally an update will run into a conflict — usually because you edited a template-managed file locally. `/rhiza:update` resolves conflicts against the template upstream as it builds the PR, but you still decide what to keep. Your options:
 
 1. **Accept the template version**: If the template's version is better, take it and discard your local change.
-2. **Keep your local version and exclude the file**: Add the file to `exclude:` in `template.yml` so future syncs skip it. Resolve the conflict in favour of your version.
-3. **Merge both sets of changes manually**: Edit the file to incorporate what you need from both the template and your local version, then mark the conflict resolved.
+2. **Keep your local version and exclude the file**: Add the file to `exclude:` in `template.yml` so future updates skip it, then keep your version.
+3. **Merge both sets of changes manually**: Edit the file to incorporate what you need from both the template and your local version, then push to the PR branch.
 
 The cleanest long-term approach is to avoid editing template-managed files directly. If you need custom behaviour, use the extension points described in Lesson 10.
 
-## Triggering sync manually
+## Running an update
 
-To run a sync without waiting for the schedule:
+To pull in the latest template version at any time, run in Claude Code:
 
-```bash
-# Via the Makefile
-make sync
-
-# Or directly via the CLI
-uvx rhiza sync
+```
+/rhiza:update
 ```
 
-This writes updated files to disk. Review the changes with `git diff`, commit them, and push.
+This bumps your `ref:` to the latest release, syncs the changed files, resolves conflicts, runs the quality gates, and opens a PR with a scorecard. Review the PR, then merge.
 
 ---
 

--- a/lessons/09-renovate.md
+++ b/lessons/09-renovate.md
@@ -1,40 +1,40 @@
 # Lesson 9 — Renovate
 
-[Renovate](https://docs.renovatebot.com/) is an open-source dependency update bot. It scans your repositories for version pins and opens pull requests whenever a newer version is available. For most projects that means bumping package versions in `requirements.txt` or `pyproject.toml`. For Rhiza-managed projects, it does something more important: it keeps the `ref:` in `.rhiza/template.yml` up to date so your project always has the option to receive the latest template changes.
+[Renovate](https://docs.renovatebot.com/) is an open-source dependency update bot. It scans your repositories for version pins and opens pull requests whenever a newer version is available. For most projects that means bumping package versions in `requirements.txt` or `pyproject.toml`. For Rhiza-managed projects, it does one more thing: it watches the `ref:` in `.rhiza/template.yml` and tells you when a newer template release is available, so a new version never slips by unnoticed.
 
 ## The problem Renovate solves for Rhiza
 
-Consider what happens after you run `uvx rhiza sync` for the first time with `ref: v0.19.3` pinned in your `template.yml`. Everything is wired up — CI, linting, releases. Six months later the template is at `v0.24.0` with security fixes, updated runner versions, and a new linting rule. Your project is still on `v0.19.3`.
+Consider what happens after you first bring a project onto the template with `ref: v1.2.0` pinned in your `template.yml`. Everything is wired up — CI, linting, releases. Six months later the template has moved on with security fixes, updated runner versions, and a new linting rule. Your project is still on `v1.2.0`.
 
-Without Renovate, nothing happens. The template has moved, but your `ref:` is still pinned to the old version. You have to notice the new release yourself, manually update the file, re-run `uvx rhiza sync`, and open a PR. Across a handful of projects this is manageable. Across twenty or thirty it becomes the same problem Rhiza was built to solve in the first place: inconsistency through neglect.
+Without Renovate, nothing tells you. The template has moved, but your `ref:` is still pinned to the old version. You have to notice the new release yourself and run `/rhiza:update`. Across a handful of projects this is manageable. Across twenty or thirty it becomes the same problem Rhiza was built to solve in the first place: inconsistency through neglect.
 
-Renovate closes this loop automatically. It opens a PR whenever a new template version is tagged, so every project receives a signal that says: *there is a new version — do you want it?*
+Renovate closes this gap. It opens a PR whenever a new template release is tagged, so every project receives a signal that says: *there is a new version.* You still decide when to adopt it.
 
 ## The two-part update flow
 
-Rhiza separates *knowing a new version exists* from *applying what changed in it*. Renovate handles the first part; the sync workflow handles the second.
+Rhiza separates *knowing a new version exists* from *applying what changed in it*. Renovate handles the first part — the notification. You handle the second by running `/rhiza:update`.
 
 ```
-template repo publishes v0.19.3
+template repo publishes v1.2.0
          │
          ▼
-Renovate opens PR: ref: v0.19.2 → v0.19.3
+Renovate opens PR: ref: v1.1.0 → v1.2.0   (notification only)
          │
-         ▼ (you review and merge)
-sync workflow triggers
+         ▼ (you learn a new version exists)
+you run /rhiza:update in Claude Code
          │
          ▼
-updated CI files, linting config, etc. land in your repo
+ref bump + updated CI files, linting config, etc. land in a PR with a scorecard
 ```
 
-The Renovate PR contains a single meaningful change: one line in `template.yml`. The sync PR that follows it contains the actual file changes that came with that new template version. Keeping these separate means you can review *whether* to upgrade independently from *what the upgrade contains*.
+The Renovate PR contains a single line change in `template.yml`. Merging it on its own does **not** apply the new template files — there is no sync workflow that reacts to it. It is a prompt. When you are ready, `/rhiza:update` performs the real update: it bumps the ref and materialises the changed files together in one reviewable PR. (You can also skip the Renovate signal entirely and run `/rhiza:status --check` to see whether you are behind, then `/rhiza:update`.)
 
 ## What a Renovate PR looks like
 
-When a new template tag is published, Renovate opens a PR with a title like:
+When a new template release is published, Renovate opens a PR with a title like:
 
 ```
-Update dependency Jebel-Quant/rhiza to v0.19.3
+Update dependency Jebel-Quant/rhiza to v1.2.0
 ```
 
 The diff is minimal:
@@ -42,16 +42,16 @@ The diff is minimal:
 ```diff
 # .rhiza/template.yml
  repository: Jebel-Quant/rhiza
--ref: v0.19.2
-+ref: v0.19.3
+-ref: v1.1.0
++ref: v1.2.0
 ```
 
 The PR body includes a changelog summary (when the template repo provides one), a confidence indicator based on how many other repos have already merged this update, and links to the release notes.
 
-Before merging:
+When you see this PR:
 1. Check the template repo's [releases page](https://github.com/Jebel-Quant/rhiza/releases) for the release notes of the new version.
 2. Scan for breaking changes — especially if the bump spans multiple minor versions.
-3. Merge the Renovate PR. The sync workflow will then apply the new files in a follow-up PR.
+3. Run `/rhiza:update` to actually adopt the version. It opens a follow-up PR with the file changes and a quality scorecard. (You can close the Renovate notification PR — `/rhiza:update` sets the ref itself.)
 
 ## How Rhiza ships Renovate configuration
 
@@ -76,11 +76,11 @@ Renovate does not know about `.rhiza/template.yml` by default — it is not a st
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^\\.rhiza/template\\.yml$"],
+      "managerFilePatterns": ["/(^|/)\\.rhiza/template\\.yml$/"],
       "matchStrings": [
         "repository:\\s*(?<depName>[^\\n]+)\\nref:\\s*(?<currentValue>[^\\n]+)"
       ],
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver"
     }
   ]
@@ -91,7 +91,7 @@ This tells Renovate:
 - Look in `.rhiza/template.yml`
 - Extract the `repository:` field as the dependency name (e.g. `Jebel-Quant/rhiza`)
 - Extract the `ref:` field as the current version
-- Check the GitHub tags API for newer semver tags
+- Check the GitHub releases API for newer semver releases
 - Open a PR when one is found
 
 You do not need to write or maintain this regex yourself — it ships with the `renovate` bundle and is kept up to date by Rhiza.
@@ -125,9 +125,7 @@ jobs:
           token: ${{ secrets.RENOVATE_TOKEN }}
 ```
 
-You control the token scope, run frequency, and log verbosity. The trade-off is that you manage the infrastructure yourself.
-
-The Rhiza `github` bundle ships a `rhiza_renovate.yml` workflow that implements this pattern when you opt for self-hosting.
+You control the token scope, run frequency, and log verbosity. The trade-off is that you manage the infrastructure and the workflow file yourself.
 
 ## Practical configuration options
 
@@ -160,7 +158,7 @@ If you trust your test suite and want zero-touch patch updates:
 }
 ```
 
-Only enable automerge once your CI is comprehensive. For the Rhiza `ref:` specifically, you likely want manual review even for patch bumps — a new template version may change CI files in ways worth reading before they land.
+Only enable automerge once your CI is comprehensive. For the Rhiza `ref:` specifically, leave automerge off — the ref-bump PR is a notification, and merging it does not apply the new template files anyway. You want to read the release notes and then run `/rhiza:update` deliberately.
 
 ### Grouping updates
 
@@ -189,19 +187,19 @@ To avoid a flood of PRs on initial setup:
 
 ## Why this matters at Rhiza scale
 
-Rhiza exists because letting boilerplate drift across many repos is expensive. Renovate closes the last gap in that argument: without it, the `ref:` pin is effectively frozen unless someone remembers to update it.
+Rhiza exists because letting boilerplate drift across many repos is expensive. Renovate closes the last gap in that argument: without it, the `ref:` pin is effectively invisible unless someone remembers to check for new releases.
 
-With Renovate in place, the full lifecycle runs without manual intervention:
+With Renovate in place, the lifecycle runs with minimal manual scanning:
 
 1. The template repo ships a new version.
-2. Renovate opens a one-line PR in every subscriber repo.
-3. A reviewer merges it (or automerge handles it for patch bumps).
-4. The sync workflow opens a PR with the actual file changes.
-5. The reviewer merges the sync PR.
+2. Renovate opens a one-line notification PR in every subscriber repo.
+3. A reviewer reads the release notes and decides whether to adopt it.
+4. Running `/rhiza:update` bumps the ref, applies the file changes, and opens a PR with a quality scorecard.
+5. The reviewer merges that update PR.
 
-No manual scanning of the template repo. No `ref:` versions left behind. Every project stays within a few weeks of the latest template — or opts out deliberately via the `exclude:` mechanism.
+No manual scanning of the template repo. No new release left unnoticed. Every project stays within a few weeks of the latest template — or opts out deliberately via the `exclude:` mechanism.
 
-For a team running ten or more Rhiza-managed repos, Renovate is not optional infrastructure. It is the mechanism that makes the living-template model work at scale.
+For a team running ten or more Rhiza-managed repos, Renovate is not optional infrastructure. It is the notification layer that keeps the living-template model working at scale.
 
 ## Renovate on GitLab
 

--- a/lessons/10-customizing-safely.md
+++ b/lessons/10-customizing-safely.md
@@ -1,10 +1,10 @@
 # Lesson 10 — Customising Safely
 
-Rhiza manages a set of files in your project. This raises an obvious question: what if you need to change something that Rhiza controls? This lesson covers the right ways to customise a Rhiza-managed project without getting into conflicts with the sync.
+Rhiza manages a set of files in your project. This raises an obvious question: what if you need to change something that Rhiza controls? This lesson covers the right ways to customise a Rhiza-managed project without getting into conflicts when you update.
 
 ## The core rule
 
-> If you edit a file that Rhiza manages, the next sync will overwrite your change.
+> If you edit a file that Rhiza manages, the next `/rhiza:update` will overwrite your change.
 
 This is intentional. Template-managed files are meant to stay consistent with the template. The right response to needing a customisation is not to edit the file — it is to use one of the extension mechanisms described below.
 
@@ -25,7 +25,7 @@ seed-db:  ## Seed the local development database
 	python scripts/seed_db.py
 ```
 
-After adding this, `make seed-db` will work alongside all the standard Rhiza targets, and it will never be touched by a sync.
+After adding this, `make seed-db` will work alongside all the standard Rhiza targets, and it will never be touched by an update.
 
 ## Option 2: Exclude a file and own it locally
 
@@ -36,7 +36,7 @@ exclude: |
   .github/workflows/rhiza_ci.yml
 ```
 
-From that point on, the sync will never touch that file. You are responsible for maintaining it, including applying any relevant upstream changes manually.
+From that point on, `/rhiza:update` will never touch that file. You are responsible for maintaining it, including applying any relevant upstream changes manually.
 
 > **Warning:** Be deliberate here. Excluded files are excluded permanently until you remove them from the list. Security fixes in the template will not reach excluded files automatically.
 
@@ -62,11 +62,11 @@ This pattern scales well: one place to manage standards, automated propagation t
 
 ## What you should never do
 
-**Don't edit template-managed files directly** unless you also add them to `exclude:`. You will lose your changes on the next sync.
+**Don't edit template-managed files directly** unless you also add them to `exclude:`. You will lose your changes the next time you run `/rhiza:update`.
 
-**Don't disable the sync workflow** to avoid dealing with PRs. The PRs are the system working correctly. If you are getting too many PRs, the right answer is to use `exclude:` for files you own locally, or to reduce how often you sync.
+**Don't work around updates** to avoid dealing with PRs. The `/rhiza:update` PR is the system working correctly. If an update surfaces too many changes you don't want, the right answer is to use `exclude:` for files you own locally, not to stop updating.
 
-**Don't diverge silently.** If you make a local change and do not exclude the file, the next sync PR will show the revert of your change. This is confusing for reviewers. Be explicit: if you own a file, exclude it.
+**Don't diverge silently.** If you make a local change and do not exclude the file, the next `/rhiza:update` PR will show the revert of your change. This is confusing for reviewers. Be explicit: if you own a file, exclude it.
 
 ## Summary of extension points
 
@@ -76,8 +76,6 @@ This pattern scales well: one place to manage standards, automated propagation t
 | Custom environment variables for `make` | Edit `custom-env.mk` |
 | Permanently own a specific file | Add to `exclude:` in `template.yml` |
 | Customise the template itself for your whole org | Fork the template repo |
-
----
 
 ---
 

--- a/lessons/11-the-rhiza-ecosystem.md
+++ b/lessons/11-the-rhiza-ecosystem.md
@@ -1,28 +1,44 @@
 # Lesson 11 — The Rhiza Ecosystem
 
-The lessons so far have focused on the core workflow: configure `template.yml`, run `uvx rhiza sync`, review sync PRs. But Rhiza is one piece of a larger set of tools built around the same philosophy — automate the boring parts of running Python projects at scale. This lesson maps that ecosystem so you know what exists and when to reach for it.
+The lessons so far have focused on the core workflow: configure `template.yml`, run `/rhiza:update`, review the resulting PR. But Rhiza is one piece of a larger set of tools built around the same philosophy — automate the boring parts of running Python projects at scale. This lesson maps that ecosystem so you know what exists and when to reach for it.
 
-## rhiza-cli — the CLI you have been using
+## rhiza-claude — the interface you have been using
 
-[`rhiza-cli`](https://github.com/Jebel-Quant/rhiza-cli) is the package behind `uvx rhiza`. It is what you run directly:
+[`rhiza-claude`](https://github.com/Jebel-Quant/rhiza-claude) is a [Claude Code](https://claude.com/claude-code) plugin marketplace. It ships the **`rhiza`** plugin — the set of slash commands that drive the whole init-sync-quality workflow from inside your AI coding assistant. It is the primary way you interact with Rhiza today: the commands wrap the underlying mechanics, and their bundled scripts are stdlib-only Python, so there is no separate CLI to install. The plugin reads `.rhiza/template.lock` and `.rhiza/template.yml` directly.
+
+Install it once:
+
+```
+/plugin marketplace add Jebel-Quant/rhiza-claude
+/plugin install rhiza@rhiza-claude
+```
+
+Pin a version by appending a git tag: `/plugin marketplace add Jebel-Quant/rhiza-claude#v0.4.1`. The only prerequisites are `uv`, `git`, and `make`.
+
+The commands appear namespaced under the plugin. The primary ones drive the day-to-day lifecycle:
 
 | Command | What it does |
 |---------|-------------|
-| `uvx rhiza init` | Creates `.rhiza/template.yml` interactively |
-| `uvx rhiza sync` | Fetches template files and writes them into the project |
-| `uvx rhiza validate` | Validates `template.yml` syntax and checks that the referenced repo and ref exist |
-| `uvx rhiza migrate` | Transitions projects from older Rhiza config layouts to the current `.rhiza/` folder structure |
+| `/rhiza:init` | Bootstraps a rhiza-managed repo in the current folder — `git init` if needed, asks GitHub/GitLab, owner/name/visibility, language (Python or Go) and template repo, optionally scaffolds `pyproject.toml` + `src/` + `tests/` + `mkdocs.yml` + a starter README, validates, and opens a PR on a `rhiza_init_<date>` branch |
+| `/rhiza:update` | Bumps the repo to the latest (or a given) rhiza release, syncs the template, resolves conflicts, runs the quality gates, and opens a PR with a quality scorecard — this is how you apply template changes |
+| `/rhiza:quality` | Runs the code-quality gate (lint, types, docs, deps, security, tests, test-layout, complexity, architecture) and scores the repo; can file findings as issues |
+| `/rhiza:revisit` | Creates or refreshes the repo's `README.md`, `CLAUDE.md`, and `mkdocs.yml` — refreshing badges and correcting drift while preserving hand-written prose |
+| `/rhiza:stats` | Read-only statistics dashboard for the repo (lines of code, test ratio, stars, coverage, complexity, dependencies, template status); writes `docs/stats.html` |
+| `/rhiza:repos` | Lists GitHub repos tagged with a rhiza topic (default `rhiza`) as JSON |
+| `/rhiza:release` | Derives the next semantic version from the conventional commits since the last tag (via git-cliff), bumps `pyproject.toml`, regenerates `CHANGELOG.md`, then commits and tags locally — stopping before pushing |
+| `/rhiza:new` | Scaffolds `src/<pkg>/<name>.py` plus its mirrored `tests/<pkg>/test_<name>.py`, keeping the 1:1 layout parity that `/rhiza:quality` enforces; never overwrites |
 
-You rarely need to install `rhiza-cli` globally — `uvx` handles it on demand. The Makefile target (`make sync`) calls `uvx rhiza` under the hood.
+A second group of repo utilities is read-only (or destructive but explicit) and works straight off the lock file:
 
-The `core` bundle also ships two Makefile targets that are useful for everyday diagnostics:
+| Command | What it does |
+|---------|-------------|
+| `/rhiza:status` | Shows the sync status — template repository, ref, synced commit SHA, timestamp, and strategy; `--files`/`--tree` lists managed files, `--check` compares the pinned ref against the latest upstream release |
+| `/rhiza:validate` | Validates that `.rhiza/template.yml` parses and its fields are well-typed; exits non-zero on failure |
+| `/rhiza:uninstall` | Removes every file listed in `.rhiza/template.lock`, prunes emptied directories, and deletes the lock; destructive, so it prompts unless `--force` |
 
-| Target | What it does |
-|--------|-------------|
-| `make doctor` | Validates your project and environment — required tools, Python version consistency, `.rhiza/` config |
-| `make explain-bundles` | Lists all available bundles with descriptions, dependency relationships, and platform grouping |
+Start with `/rhiza:status` and `/rhiza:validate` when something looks wrong — the first tells you what was synced and whether you are behind, the second confirms your config is well-formed.
 
-Start with `make doctor` when something is wrong. Run `make explain-bundles` when you are planning which bundles to add.
+> Historically, the mechanics lived in two separate packages — `rhiza-cli` (the `uvx rhiza` command) and `rhiza-tools` (release and reporting utilities). Both are now archived: `rhiza-claude` supersedes the CLI, and the reporting/matrix logic moved inside the template's reusable CI workflows. You no longer run `uvx rhiza` or `uvx rhiza-tools` for anything.
 
 ## rhiza-hooks — pre-commit hooks
 
@@ -37,43 +53,7 @@ Start with `make doctor` when something is wrong. Run `make explain-bundles` whe
 | `check-template-bundles` | The bundles listed in `template.yml` exist in the remote template repo |
 | `update-readme-help` | Embeds the current `make help` output into the README automatically |
 
-These run locally on commit. The same checks also run in CI via the `rhiza_pre-commit.yml` workflow, so nothing slips through if someone bypasses the local hooks.
-
-## rhiza-tools — release and project utilities
-
-[`rhiza-tools`](https://github.com/Jebel-Quant/rhiza-tools) is a collection of utility commands that the Rhiza Makefile exposes as `make` targets. It installs as a plugin for `rhiza-cli`, so you can also call the commands directly as `rhiza tools <command>` (via `uvx "rhiza[tools]" tools <command>`), or standalone with `uvx rhiza-tools <command>`:
-
-| Command | What it does |
-|---------|-------------|
-| `bump` | Bumps the version in `pyproject.toml` (major, minor, or patch) |
-| `release` | Pushes a version tag to trigger the release workflow |
-| `update-readme` | Refreshes the `make help` section in `README.md` |
-| `version-matrix` | Reads `requires-python` from `pyproject.toml` and emits a JSON matrix for GitHub Actions |
-| `analyze-benchmarks` | Processes pytest-benchmark results and generates an interactive HTML report |
-
-Most of the time you will reach these through `make bump`, `make release`, and so on rather than calling `uvx rhiza-tools` directly. But knowing the underlying tool exists means you can call it in custom scripts or extend it.
-
-## rhiza-config — Rhiza commands for Claude Code
-
-[`rhiza-config`](https://github.com/Jebel-Quant/rhiza-config) is a [Claude Code](https://claude.com/claude-code) plugin marketplace. It ships the **`rhiza`** plugin — a set of slash commands that drive the whole sync-and-quality workflow from inside your AI coding assistant, so you do not have to remember the underlying `make` and `uvx` invocations.
-
-Install it once:
-
-```
-/plugin marketplace add Jebel-Quant/rhiza-config
-/plugin install rhiza@rhiza-config
-```
-
-The commands then appear namespaced under the plugin:
-
-| Command | What it does |
-|---------|-------------|
-| `/rhiza:boost` | Bumps the repo to the latest (or a given) rhiza release, syncs the template, resolves conflicts, runs the quality gates, and opens a PR with a quality scorecard |
-| `/rhiza:quality` | Runs the code-quality gate (lint, types, docs, deps, security, tests, complexity, architecture) and scores the repo |
-| `/rhiza:revisit` | Creates or refreshes the repo's `README.md`, `CLAUDE.md`, and `mkdocs.yml` — refreshing badges and correcting drift while preserving hand-written prose |
-| `/rhiza:stats` | Read-only statistics dashboard for the repo (lines of code, test ratio, stars, coverage, complexity, template status) |
-
-Where `rhiza-cli` automates the mechanics of syncing, `rhiza-config` automates the *judgement* around it — deciding when to bump, scoring quality, and keeping docs honest — by handing those tasks to Claude Code with the right context baked in. It is optional: everything the plugin does can also be done by hand with the CLI and Makefile targets.
+These run locally on commit. The template's CI enforces the equivalent quality gates as well, so nothing slips through if someone bypasses the local hooks.
 
 ## rhiza-brainbug — cross-repo test harness
 
@@ -90,30 +70,28 @@ This makes it the ecosystem's answer to "did my change break a downstream repo?"
                     │       template repo          │
                     │          (rhiza)             │
                     └─────────────┬───────────────┘
-                                  │ sync PRs
+                                  │ template files
+                    ┌─────────────▼───────────────┐
+                    │        rhiza-claude          │
+                    │  init · update · quality     │
+                    │  revisit · stats · release   │
+                    │  status · validate · …       │
+                    └─────────────┬───────────────┘
+                                  │ drives
                     ┌─────────────▼───────────────┐
                     │       your project           │
-                    │  .rhiza/template.yml         │
-                    └──┬──────────┬───────────────┘
-                       │          │
-          ┌────────────▼──┐  ┌───▼────────────────┐
-          │  rhiza-cli    │  │   rhiza-hooks       │
-          │  init         │  │   (pre-commit)      │
-          │  sync         │  └────────────────────┘
-          │  validate     │
-          └────────────┬──┘
+                    │  .rhiza/template.yml + .lock │
+                    └──┬───────────────────────────┘
                        │
-          ┌────────────▼──────────────────────────┐
-          │            rhiza-tools                │
-          │  bump · release · version-matrix      │
-          │  coverage-badge · analyze-benchmarks  │
-          └───────────────────────────────────────┘
+          ┌────────────▼────────┐
+          │   rhiza-hooks       │
+          │   (pre-commit)      │
+          └─────────────────────┘
 
-   AI layer (optional):  rhiza-config   → /rhiza:boost · quality · revisit · stats
    Cross-repo testing:   rhiza-brainbug → contract/compatibility runs on upstream commits
 ```
 
-At the top is the template repo (Rhiza). `rhiza-cli` is how you interact with it from inside a project. `rhiza-hooks` keeps the project valid on every commit. `rhiza-tools` handles the release and reporting tasks that the CI workflows call on. `rhiza-config` layers Claude Code slash commands over that workflow when you want the assistant to drive it, and `rhiza-brainbug` runs the compatibility tests that span multiple Rhiza projects.
+At the top is the template repo (Rhiza). `rhiza-claude` is the interface layer: its slash commands materialize template files into your project, run the quality gates, and keep the docs honest — all driven from Claude Code. `rhiza-hooks` keeps the project valid on every commit, and `rhiza-brainbug` runs the compatibility tests that span multiple Rhiza projects.
 
 ---
 

--- a/lessons/12-further-reading.md
+++ b/lessons/12-further-reading.md
@@ -6,15 +6,14 @@ All links point directly to the Markdown source on GitHub. Every file listed her
 
 ---
 
-## Getting started and CLI usage
+## Getting started and command usage
 
-These live in [`rhiza-cli`](https://github.com/Jebel-Quant/rhiza-cli) alongside the source code.
+The primary interface is the `rhiza` plugin shipped by [`rhiza-claude`](https://github.com/Jebel-Quant/rhiza-claude), documented on its [docs site](https://jebel-quant.github.io/rhiza-claude/) — a page per command.
 
 | Document | What it covers |
 |----------|---------------|
-| [GETTING_STARTED.md](https://github.com/Jebel-Quant/rhiza-cli/blob/main/GETTING_STARTED.md) | End-to-end walkthrough of adopting Rhiza in a new project — the narrative version of Lesson 6 |
-| [CLI.md](https://github.com/Jebel-Quant/rhiza-cli/blob/main/CLI.md) | One-page command reference: every flag and subcommand with examples |
-| [USAGE.md](https://github.com/Jebel-Quant/rhiza-cli/blob/main/USAGE.md) | Practical tutorials and real-world usage patterns, including edge cases |
+| [rhiza-claude docs](https://jebel-quant.github.io/rhiza-claude/) | Installing the marketplace and the full `/rhiza:*` command set, one page per command — the reference for `init`, `update`, `quality`, and the rest |
+| [`jebel-quant/rhiza` README](https://github.com/Jebel-Quant/rhiza/blob/main/README.md) | The template repo itself — bundles, structure, and how the template files land in your project |
 
 ---
 
@@ -55,19 +54,20 @@ Each bundle has its own guide in [`rhiza/docs/`](https://github.com/Jebel-Quant/
 
 ---
 
-## rhiza-tools command reference
+## Command reference
 
-Each command in [`rhiza-tools`](https://github.com/Jebel-Quant/rhiza-tools) has a dedicated doc in [`docs/commands/`](https://github.com/Jebel-Quant/rhiza-tools/tree/main/docs/commands).
+Each `/rhiza:*` command has a dedicated page on the [rhiza-claude docs site](https://jebel-quant.github.io/rhiza-claude/).
 
 | Document | Command | What it covers |
 |----------|---------|---------------|
-| [bump.md](https://github.com/Jebel-Quant/rhiza-tools/blob/main/docs/commands/bump.md) | `rhiza-tools bump` | Semantic version bumping in `pyproject.toml` |
-| [release.md](https://github.com/Jebel-Quant/rhiza-tools/blob/main/docs/commands/release.md) | `rhiza-tools release` | Pushing a release tag to trigger the release workflow |
-| [version_matrix.md](https://github.com/Jebel-Quant/rhiza-tools/blob/main/docs/commands/version_matrix.md) | `rhiza-tools version-matrix` | Extracting Python versions from `pyproject.toml` for CI matrices |
-| [analyze_benchmarks.md](https://github.com/Jebel-Quant/rhiza-tools/blob/main/docs/commands/analyze_benchmarks.md) | `rhiza-tools analyze-benchmarks` | Processing pytest-benchmark results into an interactive HTML report |
-| [update_readme.md](https://github.com/Jebel-Quant/rhiza-tools/blob/main/docs/commands/update_readme.md) | `rhiza-tools update-readme` | Embedding `make help` output into `README.md` |
-| [rollback.md](https://github.com/Jebel-Quant/rhiza-tools/blob/main/docs/commands/rollback.md) | `rhiza-tools rollback` | Rolling back a release tag |
-| [configuration.md](https://github.com/Jebel-Quant/rhiza-tools/blob/main/docs/configuration.md) | — | The `.rhiza/.cfg.toml` configuration file and bump-my-version integration |
+| [update](https://jebel-quant.github.io/rhiza-claude/) | `/rhiza:update` | Bump to the latest release, sync the template, resolve conflicts, and open a scorecard PR |
+| [quality](https://jebel-quant.github.io/rhiza-claude/) | `/rhiza:quality` | Run the code-quality gate and score the repo |
+| [release](https://jebel-quant.github.io/rhiza-claude/) | `/rhiza:release` | Derive the next semver from conventional commits, bump `pyproject.toml`, regenerate `CHANGELOG.md`, commit and tag locally |
+| [stats](https://jebel-quant.github.io/rhiza-claude/) | `/rhiza:stats` | Read-only statistics dashboard; writes `docs/stats.html` |
+| [status](https://jebel-quant.github.io/rhiza-claude/) | `/rhiza:status` | Show sync status from `.rhiza/template.lock`; `--check` reports whether you are behind |
+| [new](https://jebel-quant.github.io/rhiza-claude/) | `/rhiza:new` | Scaffold a source module and its mirrored test file |
+
+> The version-matrix and coverage-badge logic that used to be user-run `rhiza-tools` commands now lives inside the template's reusable CI workflows (`rhiza_ci.yml`), so there is nothing to invoke by hand.
 
 ---
 
@@ -82,15 +82,15 @@ Each command in [`rhiza-tools`](https://github.com/Jebel-Quant/rhiza-tools) has 
 
 ## Claude Code integration
 
-The [`rhiza-config`](https://github.com/Jebel-Quant/rhiza-config) plugin marketplace ships the `rhiza` plugin — slash commands that drive the sync and quality workflow from Claude Code. Each command has its source in [`commands/`](https://github.com/Jebel-Quant/rhiza-config/tree/main/commands).
+The [`rhiza-claude`](https://github.com/Jebel-Quant/rhiza-claude) plugin marketplace ships the `rhiza` plugin — the slash commands that drive the whole init, sync, and quality workflow from Claude Code. The full reference lives on its [docs site](https://jebel-quant.github.io/rhiza-claude/).
 
 | Document | Command | What it covers |
 |----------|---------|---------------|
-| [README.md](https://github.com/Jebel-Quant/rhiza-config/blob/main/README.md) | — | Installing the marketplace and the full command list |
-| [boost.md](https://github.com/Jebel-Quant/rhiza-config/blob/main/commands/boost.md) | `/rhiza:boost` | Bump to the latest release, sync, resolve conflicts, and open a scorecard PR |
-| [quality.md](https://github.com/Jebel-Quant/rhiza-config/blob/main/commands/quality.md) | `/rhiza:quality` | Run the code-quality gate and score the repo |
-| [revisit.md](https://github.com/Jebel-Quant/rhiza-config/blob/main/commands/revisit.md) | `/rhiza:revisit` | Refresh `README.md`, `CLAUDE.md`, and `mkdocs.yml` |
-| [stats.md](https://github.com/Jebel-Quant/rhiza-config/blob/main/commands/stats.md) | `/rhiza:stats` | Read-only statistics dashboard for the repo |
+| [rhiza-claude README](https://github.com/Jebel-Quant/rhiza-claude/blob/main/README.md) | — | Installing the marketplace and the full command list |
+| [update](https://jebel-quant.github.io/rhiza-claude/) | `/rhiza:update` | Bump to the latest release, sync, resolve conflicts, and open a scorecard PR |
+| [quality](https://jebel-quant.github.io/rhiza-claude/) | `/rhiza:quality` | Run the code-quality gate and score the repo |
+| [revisit](https://jebel-quant.github.io/rhiza-claude/) | `/rhiza:revisit` | Refresh `README.md`, `CLAUDE.md`, and `mkdocs.yml` |
+| [stats](https://jebel-quant.github.io/rhiza-claude/) | `/rhiza:stats` | Read-only statistics dashboard for the repo |
 
 ---
 
@@ -109,8 +109,8 @@ These live in `.rhiza/docs/` and are synced into every Rhiza-managed project via
 | Document | What it covers |
 |----------|---------------|
 | [WORKFLOWS.md](https://github.com/Jebel-Quant/rhiza/blob/main/.rhiza/docs/WORKFLOWS.md) | Recommended day-to-day development workflows: branching, dependency updates, debugging CI |
-| [RELEASING.md](https://github.com/Jebel-Quant/rhiza/blob/main/.rhiza/docs/RELEASING.md) | Full release process: from `make bump` to a published PyPI package |
-| [TOKEN_SETUP.md](https://github.com/Jebel-Quant/rhiza/blob/main/.rhiza/docs/TOKEN_SETUP.md) | How to create and configure a `PAT_TOKEN` for the sync and release workflows |
+| [RELEASING.md](https://github.com/Jebel-Quant/rhiza/blob/main/.rhiza/docs/RELEASING.md) | Full release process: from `/rhiza:release` to a published PyPI package |
+| [TOKEN_SETUP.md](https://github.com/Jebel-Quant/rhiza/blob/main/.rhiza/docs/TOKEN_SETUP.md) | How to create and configure a `PAT_TOKEN` for the release workflow and PR automation |
 | [PRIVATE_PACKAGES.md](https://github.com/Jebel-Quant/rhiza/blob/main/.rhiza/docs/PRIVATE_PACKAGES.md) | Using private GitHub packages as dependencies in Rhiza-managed projects |
 
 ---
@@ -120,8 +120,7 @@ These live in `.rhiza/docs/` and are synced into every Rhiza-managed project via
 | Document | Repo | What it covers |
 |----------|------|---------------|
 | [CONTRIBUTING.md](https://github.com/Jebel-Quant/rhiza/blob/main/CONTRIBUTING.md) | rhiza | How to contribute to the core template repo |
-| [CONTRIBUTING.md](https://github.com/Jebel-Quant/rhiza-cli/blob/main/CONTRIBUTING.md) | rhiza-cli | How to contribute to the CLI |
-| [CONTRIBUTING.md](https://github.com/Jebel-Quant/rhiza-tools/blob/main/CONTRIBUTING.md) | rhiza-tools | How to contribute utilities |
+| [rhiza-claude README](https://github.com/Jebel-Quant/rhiza-claude/blob/main/README.md) | rhiza-claude | How to contribute to the `rhiza` plugin and its commands |
 | [CONTRIBUTING.md](https://github.com/Jebel-Quant/rhiza-hooks/blob/main/CONTRIBUTING.md) | rhiza-hooks | How to contribute pre-commit hooks |
 
 ---

--- a/lessons/A1-gitlab-users.md
+++ b/lessons/A1-gitlab-users.md
@@ -7,9 +7,9 @@ Rhiza has full GitLab CI/CD support. If your project lives on GitLab rather than
 Everything in lessons 1–6 applies equally to GitLab:
 
 - The `.rhiza/template.yml` config file works identically.
-- `uvx rhiza init` and `uvx rhiza sync` work identically.
+- The rhiza-claude plugin commands (`/rhiza:init`, `/rhiza:update`) work identically — `/rhiza:init` asks whether your project is on GitHub or GitLab.
 - The `templates:`, `include:`, and `exclude:` keys work identically.
-- The sync lifecycle — sync → diff → review → merge — is the same.
+- The update lifecycle — `/rhiza:update` → diff → review → merge — is the same.
 - The extension points (`custom-task.mk`, `custom-env.mk`, `exclude:`) are the same.
 
 ## What changes: use the `gitlab` bundle
@@ -19,7 +19,7 @@ When configuring your `template.yml`, replace the `github` bundle with `gitlab`:
 ```yaml
 # .rhiza/template.yml
 repository: Jebel-Quant/rhiza
-ref: v0.8.0
+ref: v1.2.0
 
 templates:
   - core
@@ -28,7 +28,7 @@ templates:
   - renovate
 ```
 
-The `gitlab` bundle provides GitLab CI/CD equivalents for all the workflows in the `github` bundle: CI testing, pre-commit, deptry, documentation, sync, and release.
+The `gitlab` bundle provides GitLab CI/CD equivalents for the workflows in the `github` bundle: CI testing, the code-quality gates, documentation, releases, and Renovate.
 
 > **Note:** Do not include both `github` and `gitlab` in the same project. Pick one.
 
@@ -40,14 +40,14 @@ After syncing, your project will have:
 .gitlab-ci.yml                   # Main CI entrypoint — includes all workflow files
 .gitlab/workflows/
   rhiza_ci.yml                   # Multi-version Python CI
-  rhiza_pre-commit.yml           # Pre-commit hooks
-  rhiza_deptry.yml               # Dependency checking
-  rhiza_validate.yml             # Rhiza config validation
+  rhiza_quality.yml              # Code-quality gates (lint, types, deps, security)
   rhiza_book.yml                 # Documentation (deploys to GitLab Pages)
-  rhiza_sync.yml                 # Scheduled template sync
   rhiza_release.yml              # Release and PyPI publishing
   rhiza_renovate.yml             # Renovate dependency updates
+  rhiza_weekly.yml               # Weekly dependency-compatibility and link checks
 ```
+
+There is no `rhiza_sync.yml` — GitLab has no automated template-sync pipeline any more than GitHub does. Template updates are applied by running `/rhiza:update`. Pre-commit hooks run locally via [rhiza-hooks](https://github.com/Jebel-Quant/rhiza-hooks) rather than as a CI workflow.
 
 ## Required CI/CD variables
 
@@ -55,28 +55,22 @@ Set these in your GitLab project under **Settings > CI/CD > Variables**:
 
 | Variable | Required for | Notes |
 |----------|-------------|-------|
-| `PAT_TOKEN` | Sync workflow | A Project or Group Access Token with `api` scope. Needed for two reasons: (1) GitLab's `CI_JOB_TOKEN` cannot create merge requests, so without PAT_TOKEN the sync runs but no MR is opened; (2) pushing changes to workflow files requires a PAT on both GitHub and GitLab — the default job token lacks that permission. |
+| `PAT_TOKEN` | Renovate MRs | A Project or Group Access Token with `api` scope. GitLab's `CI_JOB_TOKEN` cannot create merge requests, so without `PAT_TOKEN` the `rhiza_renovate.yml` job runs but no MR is opened. |
 | `PYPI_TOKEN` | Release workflow | Your PyPI API token. GitLab uses token-based authentication; OIDC Trusted Publishing is a GitHub-only feature. |
 
 Mark both as **Masked** in the variable settings so they are not exposed in pipeline logs.
 
-## Scheduling the sync pipeline
+## Keeping the template up to date
 
-The GitHub bundle sets up a scheduled workflow automatically. On GitLab, you need to configure the schedule manually:
+There is no scheduled sync pipeline on GitLab (or on GitHub). To pull the latest template changes into your project, run `/rhiza:update` from Claude Code — it works identically regardless of platform, bumps the `ref:`, applies the changed files, and opens a merge request with a quality scorecard. Run `/rhiza:status --check` any time to see whether your pinned `ref:` is behind the latest release.
 
-1. Go to **CI/CD > Schedules** in your GitLab project.
-2. Click **New schedule**.
-3. Set the cron expression (e.g. `0 9 * * 1` for every Monday at 09:00).
-4. Set the target branch to `main`.
-5. Save.
-
-The `rhiza_sync.yml` workflow will then run on that schedule, sync the latest template, and open a merge request if anything changed.
+Renovate (via the shipped `rhiza_renovate.yml` job) still opens a merge request bumping the `ref:` when a new template release is tagged, but that MR is only a notification that a new version exists — you apply the actual file changes with `/rhiza:update`.
 
 ## Key differences from the GitHub setup
 
-**Merge request creation on sync**
+**Merge request creation**
 
-On GitHub, the sync workflow creates a pull request automatically using the built-in `GITHUB_TOKEN`. On GitLab, creating a merge request from CI requires a `PAT_TOKEN` with API scope. If this token is not set, the sync will still run and apply changes, but it will not open an MR — you will need to create one manually from the resulting branch.
+On GitHub, Renovate and the release automation open pull requests using the built-in `GITHUB_TOKEN`. On GitLab, creating a merge request from CI requires a `PAT_TOKEN` with API scope. If this token is not set, the `rhiza_renovate.yml` job still runs but will not open an MR — you will need to create one manually from the resulting branch.
 
 **PyPI publishing**
 
@@ -96,4 +90,4 @@ The `renovate` bundle works on GitLab too. Renovate supports GitLab natively and
 
 ---
 
-**Back to:** [Lesson 9 — Customising Safely](./09-customizing-safely.md) | [README](../README.md)
+**Back to:** [Lesson 10 — Customising Safely](./10-customizing-safely.md) | [README](../README.md)

--- a/lessons/A2-projects-using-rhiza.md
+++ b/lessons/A2-projects-using-rhiza.md
@@ -4,25 +4,19 @@ The best evidence that a tool works is that its authors use it themselves. This 
 
 ## The Rhiza tools themselves
 
-The most direct proof of Rhiza's value is that the Rhiza ecosystem tools are all managed by Rhiza. Each one has a `.rhiza/template.yml` and receives sync PRs when the template is updated — the same workflow you set up in Lesson 6.
+The most direct proof of Rhiza's value is that the Rhiza ecosystem tools are all managed by Rhiza. Each one has a `.rhiza/template.yml` and receives an update PR when the template changes — the same `/rhiza:update` workflow you set up in Lesson 6.
 
-### rhiza-cli
+### rhiza-claude
 
-[github.com/Jebel-Quant/rhiza-cli](https://github.com/Jebel-Quant/rhiza-cli)
+[github.com/Jebel-Quant/rhiza-claude](https://github.com/Jebel-Quant/rhiza-claude)
 
-The CLI package that provides `uvx rhiza`. Being a Python tool with CI, tests, and a release workflow, it is a natural consumer of its own template. Its `template.yml` is a useful reference for what a typical `core + github + tests + renovate` setup looks like.
+The Claude Code plugin marketplace that ships the `rhiza` plugin — the primary interface to Rhiza and the source of the `/rhiza:*` commands used throughout this curriculum. It is itself a rhiza-managed repository, so its `template.yml` is a useful reference for what a tooling project's setup looks like.
 
 ### rhiza-hooks
 
 [github.com/Jebel-Quant/rhiza-hooks](https://github.com/Jebel-Quant/rhiza-hooks)
 
 The pre-commit hook repository. Because it is a Python package with its own CI and release pipeline, it uses the same Rhiza template as any other project. Notably, the `check-rhiza-config` hook it provides also validates its own `template.yml` — so every commit to rhiza-hooks runs Rhiza validation on itself.
-
-### rhiza-tools
-
-[github.com/Jebel-Quant/rhiza-tools](https://github.com/Jebel-Quant/rhiza-tools)
-
-The utility command package. Its CI pipeline uses `version-matrix` (from rhiza-tools) to generate the Python test matrix — a tool built by the project, consumed by its own CI, wired together by the Rhiza template.
 
 ## A real-world library: jquantstats
 
@@ -63,7 +57,7 @@ templates:
 
 Notable choices: the `legal` bundle (adds standard licence headers and notice files — common for projects from research institutions that need to be explicit about intellectual property) and the `marimo` bundle (interactive notebook demos of backtesting strategies published to GitHub Pages). The `book` bundle deploys API documentation on every push.
 
-> **Config format note:** This project uses the older `template-repository` / `template-branch` key names rather than the current `repository` / `ref`. The tool accepts both; `uvx rhiza migrate` can update the format automatically.
+> **Config format note:** This project uses the older `template-repository` / `template-branch` key names rather than the current `repository` / `ref`. Both key formats are still accepted.
 
 ---
 
@@ -90,7 +84,7 @@ exclude:
   - ruff.toml
 ```
 
-The `exclude: ruff.toml` is the most instructive part of this config. The project has custom linting rules that diverge from Rhiza's defaults — rather than fighting the sync, the author added `ruff.toml` to `exclude:` and manages it locally. This is exactly the pattern described in [Lesson 9](./09-customizing-safely.md).
+The `exclude: ruff.toml` is the most instructive part of this config. The project has custom linting rules that diverge from Rhiza's defaults — rather than fighting the sync, the author added `ruff.toml` to `exclude:` and manages it locally. This is exactly the pattern described in [Lesson 10](./10-customizing-safely.md).
 
 ---
 
@@ -158,4 +152,4 @@ Not every project here uses the current config format or best practices — and 
 
 ---
 
-**Back to:** [Lesson 10 — The Rhiza Ecosystem](./10-the-rhiza-ecosystem.md) | [README](../README.md)
+**Back to:** [Lesson 11 — The Rhiza Ecosystem](./11-the-rhiza-ecosystem.md) | [README](../README.md)

--- a/lessons/A3-contributors.md
+++ b/lessons/A3-contributors.md
@@ -1,6 +1,6 @@
 # Appendix A3 — Contributors
 
-Rhiza and its ecosystem are built by a small group of people. This page lists every human contributor across the five core repositories — `rhiza`, `rhiza-cli`, `rhiza-tools` and `rhiza-hooks` — with their GitHub profiles and contribution counts.
+Rhiza and its ecosystem are built by a small group of people. The current core repositories are `rhiza`, `rhiza-claude`, `rhiza-hooks`, and `rhiza-brainbug`. The now-archived `rhiza-cli` and `rhiza-tools` were core repositories earlier in the project's life, and the contribution counts below still include the work that went into them. This page lists every human contributor with their GitHub profiles and contribution counts.
 
 Contribution counts reflect commits to the default branch as of the time this page was written. Automated commits from Renovate, Copilot, and other bots are excluded.
 
@@ -111,10 +111,9 @@ Armaan contributed to the core `rhiza` template repo.
 Rhiza is open source and welcomes contributions. The best entry points are:
 
 - **[rhiza CONTRIBUTING.md](https://github.com/Jebel-Quant/rhiza/blob/main/CONTRIBUTING.md)** — for template changes
-- **[rhiza-cli CONTRIBUTING.md](https://github.com/Jebel-Quant/rhiza-cli/blob/main/CONTRIBUTING.md)** — for CLI changes
-- **[rhiza-tools CONTRIBUTING.md](https://github.com/Jebel-Quant/rhiza-tools/blob/main/CONTRIBUTING.md)** — for utility commands
+- **[rhiza-claude CONTRIBUTING.md](https://github.com/Jebel-Quant/rhiza-claude/blob/main/CONTRIBUTING.md)** — for the Claude Code plugin and the `/rhiza:*` commands
 - **[rhiza-hooks CONTRIBUTING.md](https://github.com/Jebel-Quant/rhiza-hooks/blob/main/CONTRIBUTING.md)** — for pre-commit hooks
 
 ---
 
-**Back to:** [Lesson 11 — Further Reading](./11-further-reading.md) | [README](../README.md)
+**Back to:** [Lesson 12 — Further Reading](./12-further-reading.md) | [README](../README.md)

--- a/lessons/index.md
+++ b/lessons/index.md
@@ -17,7 +17,7 @@ Welcome to the Rhiza training curriculum. These lessons teach you how to adopt, 
 | 8 | [The Sync Lifecycle](08-the-sync-lifecycle.md) | What triggers a sync PR, what it contains, and how to handle it |
 | 9 | [Renovate](09-renovate.md) | How Renovate keeps your `ref:` pin current, the two-part update flow, and how to configure it |
 | 10 | [Customising Safely](10-customizing-safely.md) | How to modify Rhiza-managed files without conflicting with future syncs |
-| 11 | [The Rhiza Ecosystem](11-the-rhiza-ecosystem.md) | rhiza-cli, rhiza-hooks, rhiza-tools, rhiza-config, and rhiza-brainbug |
+| 11 | [The Rhiza Ecosystem](11-the-rhiza-ecosystem.md) | rhiza-claude, rhiza-hooks, and rhiza-brainbug |
 | 12 | [Further Reading](12-further-reading.md) | Direct links to every doc file across the Rhiza repos, organised by topic |
 
 ## Appendices

--- a/lessons/slides.md
+++ b/lessons/slides.md
@@ -26,7 +26,7 @@ Source: [`slides/rhiza-intro.md`](https://github.com/Jebel-Quant/rhiza-education
 
 ## 60-Minute Deep Dive
 
-A comprehensive presentation covering everything in the 30-minute version plus: the hidden cost of drift, bundle internals, the `ref:` pin in depth, `rhiza init` walkthrough, PAT_TOKEN setup, OIDC publishing, conflict handling, customisation patterns, rhiza-hooks, rhiza-tools, GitLab support, and a full adoption guide.
+A comprehensive presentation covering everything in the 30-minute version plus: the hidden cost of drift, bundle internals, the `ref:` pin in depth, the `/rhiza:init` walkthrough, PAT_TOKEN setup, OIDC publishing, conflict handling, customisation patterns, rhiza-hooks, releasing with `/rhiza:release`, GitLab support, and a full adoption guide.
 
 [Open full-screen](rhiza-deep-dive.html){ .md-button .md-button--primary target=_blank }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ copyright: >
   Copyright &copy; 2026 Jebel Quant &mdash;
   <a href="/rhiza-education/license/">MIT License</a> &mdash;
   <a href="/rhiza-education/impressum/">Impressum</a> &mdash;
-  Generated with rhiza {{ rhiza_version }} / rhiza-cli {{ rhiza_cli_version }}
+  Generated with rhiza {{ rhiza_version }} / rhiza-claude {{ rhiza_claude_version }}
 
 theme:
   name: material

--- a/slides/cicd-intro.md
+++ b/slides/cicd-intro.md
@@ -359,14 +359,16 @@ Every build has a log. You can see exactly what ran, when it ran, and what it pr
 
 You don't need to write workflow files from scratch.
 
-**Rhiza** provides a ready-made CI/CD setup for Python projects:
+**Rhiza** provides a ready-made CI/CD setup for Python projects, driven from Claude Code:
 
 ```bash
-uvx rhiza init        # creates .rhiza/template.yml
-uvx rhiza sync        # writes CI workflow files into your repo
+/rhiza:init        # creates .rhiza/template.yml, first sync, opens a PR
+/rhiza:update      # later, pulls the latest CI workflow files
 ```
 
-You get: CI on every push, linting, test coverage, automated releases, and a weekly sync to keep everything up to date.
+The `/rhiza:*` commands come from the rhiza Claude Code plugin (`/plugin install rhiza@rhiza-claude`).
+
+You get: CI on every push, linting, test coverage, automated releases, and an easy way to keep everything up to date.
 
 > Learn more: **https://jebel-quant.github.io/rhiza-education/**
 
@@ -382,7 +384,7 @@ You get: CI on every push, linting, test coverage, automated releases, and a wee
 
 4. **GitHub Actions** is CI/CD built into GitHub — workflows are YAML files in your repo.
 
-5. **You don't need to build this from scratch.** Tools like Rhiza wire it up for you in four commands.
+5. **You don't need to build this from scratch.** Tools like Rhiza wire it up for you in a couple of commands.
 
 ---
 

--- a/slides/rhiza-deep-dive.md
+++ b/slides/rhiza-deep-dive.md
@@ -2,7 +2,7 @@
 marp: true
 theme: default
 paginate: true
-footer: "Rhiza — The Living Template System · jebel-quant.github.io/rhiza-education · rhiza {{ rhiza_version }} / rhiza-cli {{ rhiza_cli_version }}"
+footer: "Rhiza — The Living Template System · jebel-quant.github.io/rhiza-education · rhiza {{ rhiza_version }} / rhiza-claude {{ rhiza_claude_version }}"
 style: |
   :root {
     --color-brand: #1a5276;
@@ -59,7 +59,7 @@ Keeping every Python repo in sync — automatically
 3. **How Rhiza works** — config, bundles, the sync loop, and Renovate
 4. **Getting started** — setup, first sync, and token configuration
 5. **Living with Rhiza** — sync PRs, customisation, and conflict resolution
-6. **The ecosystem** — rhiza-hooks, rhiza-tools, and companion projects
+6. **The ecosystem** — rhiza-claude, rhiza-hooks, and companion projects
 7. **Adoption** — migrating existing repos and rolling out across a team
 
 ---
@@ -216,10 +216,10 @@ The sync is not a bulldozer. It is a proposal.
     <div style="font-weight:bold;color:#1a5276;">your project</div>
     <div style="font-size:0.82em;color:#555;margin-top:0.2em;">.rhiza/template.yml</div>
   </div>
-  <div style="color:#2e86c1;font-size:0.95em;">↑ &nbsp;sync</div>
+  <div style="color:#2e86c1;font-size:0.95em;">↑ &nbsp;/rhiza:update</div>
   <div style="background:#eaf4fc;border:2px solid #2e86c1;border-radius:8px;padding:0.7em 2.5em;text-align:center;min-width:52%;">
-    <div style="font-weight:bold;color:#1a5276;">uvx rhiza</div>
-    <div style="font-size:0.82em;color:#555;margin-top:0.2em;">the syncer — runs locally or in CI</div>
+    <div style="font-weight:bold;color:#1a5276;">rhiza-claude</div>
+    <div style="font-size:0.82em;color:#555;margin-top:0.2em;">the interface — <code>/rhiza:*</code> commands you run in Claude Code</div>
   </div>
 </div>
 
@@ -229,7 +229,7 @@ The sync is not a bulldozer. It is a proposal.
 
 ```yaml
 repository: Jebel-Quant/rhiza   # Which template repo to sync from
-ref: v0.19.3                     # Which version (pinned tag — recommended)
+ref: v1.2.0                      # Which version (pinned tag — recommended)
 
 profiles:                         # Curated bundle preset (recommended)
   - github-project
@@ -287,19 +287,17 @@ The `github` overlay provides the base platform wiring:
 
 | File | Purpose |
 |------|---------|
-| `rhiza_sync.yml` | Weekly template sync — opens the sync PR |
 | `rhiza_release.yml` | Build wheel, publish to PyPI via OIDC, create GitHub Release |
-| `rhiza_pre-commit.yml` | Run pre-commit hooks in CI |
-| `rhiza_renovate.yml` | Self-hosted Renovate runner (optional) |
+| `rhiza_codeql.yml` | CodeQL security scanning |
+| `rhiza_scorecard.yml` | OpenSSF Scorecard supply-chain checks |
 
 The `github-tests` overlay adds testing CI on top:
 
 | File | Purpose |
 |------|---------|
-| `rhiza_ci.yml` | Test matrix across Python versions on push and PRs |
+| `rhiza_ci.yml` | Test matrix across Python versions on push and PRs (matrix derived from `requires-python`) |
 
-None of these need to be written manually.
-They arrive via `uvx rhiza sync` and stay current via the sync.
+Other bundles layer in more workflows — benchmarks, mutation testing, fuzzing, a weekly dependency/link check, and a quality review. There is **no sync workflow**: template changes are applied by running `/rhiza:update`.
 
 ---
 
@@ -317,11 +315,10 @@ They arrive via `uvx rhiza sync` and stay current via the sync.
 
 1. **Fetch** — reads `template.yml`, pulls matching files from the template repo at `ref`
 2. **Diff** — compares what was fetched against what's currently in your project
-3. **Review** — if anything changed, opens a pull request with the diff
+3. **Review** — if anything changed, opens a pull request with the diff (and a quality scorecard)
 4. **Commit** — you review the PR and merge it (or close it if not relevant)
 
-Runs automatically on a **weekly schedule** via GitHub Actions.
-On-demand: `make sync` or `uvx rhiza sync`.
+Run it on demand with **`/rhiza:update`** in Claude Code — it bumps the `ref`, syncs the files, resolves conflicts, runs the quality gates, and opens the PR.
 
 ---
 
@@ -331,33 +328,33 @@ Without Renovate, the `ref:` pin is frozen. Projects drift behind the template s
 
 <div style="display:flex;flex-direction:column;gap:0.45em;margin:0.9em 0;font-size:0.93em;">
   <div style="background:#eaf4fc;border-left:4px solid #2e86c1;border-radius:0 7px 7px 0;padding:0.6em 1.1em;">
-    template repo publishes <strong>v0.19.3</strong>
+    template repo publishes <strong>v1.2.0</strong>
   </div>
   <div style="padding-left:1.1em;color:#2e86c1;">↓</div>
   <div style="background:#eaf4fc;border-left:4px solid #2e86c1;border-radius:0 7px 7px 0;padding:0.6em 1.1em;">
-    Renovate opens PR: <code>ref: v0.19.2 → v0.19.3</code> &nbsp;<span style="color:#888;">(one line diff)</span>
+    Renovate opens PR: <code>ref: v1.1.0 → v1.2.0</code> &nbsp;<span style="color:#888;">(a notification — one line diff)</span>
   </div>
-  <div style="padding-left:1.1em;color:#2e86c1;">↓ <span style="color:#888;font-size:0.88em;">you merge</span></div>
+  <div style="padding-left:1.1em;color:#2e86c1;">↓ <span style="color:#888;font-size:0.88em;">you run <code>/rhiza:update</code></span></div>
   <div style="background:#eaf4fc;border-left:4px solid #2e86c1;border-radius:0 7px 7px 0;padding:0.6em 1.1em;">
-    sync workflow applies updated CI files, linting config, etc.
+    <code>/rhiza:update</code> applies the new CI files, linting config, etc. in a PR
   </div>
 </div>
 
-Two separate PRs: **should we upgrade?** then **here's what changed.**
+Two separate steps: **should we upgrade?** (the ref-bump PR) then **here's what changed** (the `/rhiza:update` PR).
 
 ---
 
 ## The `ref:` pin in depth
 
 ```yaml
-ref: v0.19.3  # pinned tag — recommended for all production repos
+ref: v1.2.0   # pinned tag — recommended for all production repos
 ref: main     # tracks latest commit — useful during template development only
 ```
 
 **Pinning to a tag gives you:**
 - A known, auditable version — you can see exactly what each project is running
 - Safe upgrades — Renovate proposes the bump, you review before it lands
-- Easy rollback — if v0.19.3 breaks something, the cause is unambiguous
+- Easy rollback — if v1.2.0 breaks something, the cause is unambiguous
 
 **Tracking `main`** delivers template changes immediately with no review step. Use only when actively developing the template. Never in repos others depend on.
 
@@ -376,34 +373,39 @@ ref: main     # tracks latest commit — useful during template development only
 # 1. Install uv (skip if already installed)
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# 2. Initialise — writes .rhiza/template.yml interactively
-uvx rhiza init
+# 2. Bootstrap the repo — writes .rhiza/template.yml, first sync, opens a PR
+/rhiza:init
 
-# 3. Sync — fetches template files and writes them into the project
-uvx rhiza sync
+# 3. Pull the latest template — syncs files, resolves conflicts, opens a PR
+/rhiza:update
 
 # 4. Install dev environment
 make install
 ```
 
+The `/rhiza:*` commands come from the rhiza Claude Code plugin — install it once with
+`/plugin marketplace add Jebel-Quant/rhiza-claude` then `/plugin install rhiza@rhiza-claude`.
+
 That's it. Your project is now Rhiza-managed.
 
 ---
 
-## What `rhiza init` asks
+## What `/rhiza:init` asks
 
-Running `uvx rhiza init` walks you through three questions:
+Running `/rhiza:init` walks you through a few questions:
 
 ```
-? Template repository (GitHub owner/repo): Jebel-Quant/rhiza
-? Template ref (tag, branch, or commit):   v0.19.3
-? Profile or bundles to include:           github-project
+? Host and repo (GitHub or GitLab, owner/name):  Jebel-Quant/rhiza
+? Language / template repo:                       Python → Jebel-Quant/rhiza
+? Template ref (tag, branch, or commit):          v1.2.0
+? Profile or bundles to include:                  github-project
 ```
+
+Go is also supported (template `Jebel-Quant/rhiza-go`); Python is the default.
 
 The result is `.rhiza/template.yml` — one file, under version control, that describes everything Rhiza will manage in this project.
 
-After `init`, run `uvx rhiza sync` to write the actual files.
-Review the diff with `git diff` before committing.
+`/rhiza:init` runs the first sync and opens a PR on a `rhiza_init_<date>` branch — review that diff before merging.
 
 ---
 
@@ -412,12 +414,11 @@ Review the diff with `git diff` before committing.
 After syncing with `core + github + tests + renovate`:
 
 ```
-.github/workflows/rhiza_ci.yml          ← CI: test on push and PRs
-.github/workflows/rhiza_pre-commit.yml  ← Pre-commit checks in CI
-.github/workflows/rhiza_sync.yml        ← Weekly template sync
-.pre-commit-config.yaml                 ← Local commit hooks
+.github/workflows/rhiza_ci.yml          ← CI: test matrix on push and PRs
+.github/workflows/rhiza_release.yml     ← Build + publish to PyPI on a tag
+.pre-commit-config.yaml                 ← Local commit hooks (rhiza-hooks)
 ruff.toml                               ← Linting config
-Makefile                                ← make test · make lint · make release
+Makefile                                ← make test · make lint
 .python-version                         ← Pinned Python version
 .editorconfig                           ← Editor consistency
 ```
@@ -428,7 +429,7 @@ None of this required manual configuration.
 
 ## The one manual step — `PAT_TOKEN`
 
-The sync workflow opens pull requests. GitHub requires a Personal Access Token for PRs that touch `.github/workflows/` files.
+Rhiza's automation (Renovate, releases) opens pull requests. GitHub requires a Personal Access Token for PRs that touch `.github/workflows/` files.
 
 **Create a fine-grained token:**
 > GitHub → Settings → Developer settings → Personal access tokens (fine-grained)
@@ -437,7 +438,7 @@ Required permissions: `contents: write`, `pull-requests: write`, `workflows: wri
 
 Add it as `PAT_TOKEN` in your repository secrets — or as an org secret to cover all repos at once.
 
-> Without `PAT_TOKEN`, the workflow falls back to `GITHUB_TOKEN`, which cannot write workflow files. Syncs that touch workflow files will silently produce no PR.
+> Without `PAT_TOKEN`, automation falls back to `GITHUB_TOKEN`, which cannot write workflow files. PRs that touch workflow files will silently fail to open.
 
 ---
 
@@ -563,21 +564,24 @@ Audit your exclude list when bumping the template version. Ask: *"Does the new t
 | `check-python-version-consistency` | `.python-version`, `pyproject.toml`, and CI matrix agree |
 | `update-readme-help` | Embeds `make help` output into `README.md` |
 
-Runs on every `git commit`. The same checks run in CI via `rhiza_pre-commit.yml`.
+Runs on every `git commit` — catching config errors locally, before anything reaches CI.
 
 ---
 
-## rhiza-tools — release and project utilities
+## Releasing — `/rhiza:release`
 
-`uvx rhiza-tools <command>` — or via `make`:
+`/rhiza:release` prepares a release straight from your conventional-commit history:
 
-| Command | What it does |
-|---------|-------------|
-| `bump patch / minor / major` | Increments version in `pyproject.toml` |
-| `release` | Creates and pushes a git tag → triggers `rhiza_release.yml` |
-| `version-matrix` | Reads `requires-python`, emits JSON matrix for GitHub Actions |
-| `analyze-benchmarks` | Converts pytest-benchmark results to an interactive HTML report |
-| `update-readme` | Embeds `make help` output into `README.md` |
+| Step | What it does |
+|------|-------------|
+| Derive version | Reads the conventional commits since the last tag (via git-cliff) to pick the next semver |
+| Bump | Updates the version in `pyproject.toml` |
+| Changelog | Regenerates `CHANGELOG.md`, folding the unreleased commits under the new tag |
+| Commit + tag | Commits and tags locally — then stops before pushing |
+
+You review, then push the tag yourself. The pushed tag triggers `rhiza_release.yml`, which builds and publishes.
+
+The old `version-matrix` and `coverage-badge` helpers are no longer user commands — that logic now lives **inside the reusable CI workflows** (`rhiza_ci.yml` derives the test matrix from `requires-python`; the coverage badge is generated during CI).
 
 ---
 
@@ -585,17 +589,15 @@ Runs on every `git commit`. The same checks run in CI via `rhiza_pre-commit.yml`
 
 | Tool | What it does |
 |------|-------------|
-| **rhiza-cli** | `uvx rhiza init / sync / validate` — the tool you run |
+| **rhiza-claude** | Claude Code plugin — the `/rhiza:*` command set (`init`, `update`, `quality`, `release`, `revisit`, `stats`, …). The primary interface. |
 | **rhiza-hooks** | Pre-commit hooks: validate config, check version consistency |
-| **rhiza-tools** | `bump`, `release`, `version-matrix`, `coverage-badge` |
-| **rhiza-config** | Claude Code plugin: `/rhiza:boost`, `quality`, `revisit`, `stats` |
 | **rhiza-brainbug** | Cross-repo test harness: runs contract tests on upstream commits |
 
 ---
 
 ## Who's using it
 
-**The Rhiza tools themselves** — rhiza-cli, rhiza-hooks, and rhiza-tools all sync from rhiza. The system eats its own cooking.
+**The Rhiza tools themselves** — rhiza-claude and rhiza-hooks all sync from rhiza. The system eats its own cooking.
 
 **External projects:**
 
@@ -620,9 +622,9 @@ templates:
   - renovate
 ```
 
-**What changes:** CI workflows become `.gitlab-ci.yml` pipeline files. The sync job runs as a scheduled pipeline. Renovate opens merge requests. `PAT_TOKEN` → GitLab Personal Access Token with `api` scope.
+**What changes:** CI workflows become `.gitlab-ci.yml` pipeline files. Renovate opens merge requests. `PAT_TOKEN` → GitLab Personal Access Token with `api` scope.
 
-**What doesn't change:** `template.yml`, `renovate.json`, all tooling (`rhiza-cli`, `rhiza-tools`, `rhiza-hooks`).
+**What doesn't change:** `template.yml`, `renovate.json`, the tooling (`rhiza-claude`, `rhiza-hooks`), and how you sync — you still run `/rhiza:update` in Claude Code.
 
 ---
 
@@ -638,7 +640,8 @@ templates:
 **New project — the easy case:**
 
 ```bash
-uvx rhiza init && uvx rhiza sync && make install
+/rhiza:init      # scaffolds config, first sync, opens a PR
+make install
 ```
 
 Done. Rhiza-managed from day one.
@@ -646,13 +649,11 @@ Done. Rhiza-managed from day one.
 **Existing project:**
 
 ```bash
-uvx rhiza init           # creates .rhiza/template.yml
-uvx rhiza sync           # writes template files — review the diff carefully
-git add -p               # stage what makes sense
-git commit -m "chore: adopt Rhiza template"
+/rhiza:init      # detects the existing repo, scaffolds .rhiza/,
+                 # runs the first sync, opens a PR on rhiza_init_<date>
 ```
 
-The first sync on an existing repo shows a diff. Some files may already match. Others may have local customisations — preserve those via `exclude:` before committing.
+The first sync on an existing repo shows a diff in that PR. Some files may already match. Others may have local customisations — preserve those via `exclude:` in `template.yml` before merging.
 
 ---
 
@@ -677,7 +678,7 @@ The first sync on an existing repo shows a diff. Some files may already match. O
 
 **Month 2** — Add Renovate org-wide. Enable the Dependency Dashboard. Review the first round of version-bump PRs together.
 
-**Ongoing** — New projects start with `uvx rhiza init`. Legacy repos migrate at their next maintenance window.
+**Ongoing** — New projects start with `/rhiza:init`. Legacy repos migrate at their next maintenance window.
 
 **Governance** — One person or platform team owns the org's template fork. Changes go through PRs on the fork — reviewed before they propagate to all subscriber repos.
 
@@ -706,7 +707,7 @@ The first sync on an existing repo shows a diff. Some files may already match. O
 # Get started
 
 ```bash
-uvx rhiza init
+/rhiza:init
 ```
 
 *ῥίζα (ree-ZAH) — root*

--- a/slides/rhiza-intro.md
+++ b/slides/rhiza-intro.md
@@ -2,7 +2,7 @@
 marp: true
 theme: default
 paginate: true
-footer: "Rhiza — The Living Template System · jebel-quant.github.io/rhiza-education · rhiza {{ rhiza_version }} / rhiza-cli {{ rhiza_cli_version }}"
+footer: "Rhiza — The Living Template System · jebel-quant.github.io/rhiza-education · rhiza {{ rhiza_version }} / rhiza-claude {{ rhiza_claude_version }}"
 style: |
   :root {
     --color-brand: #1a5276;
@@ -183,10 +183,10 @@ The sync is not a bulldozer. It is a proposal.
     <div style="font-weight:bold;color:#1a5276;">your project</div>
     <div style="font-size:0.82em;color:#555;margin-top:0.2em;">.rhiza/template.yml</div>
   </div>
-  <div style="color:#2e86c1;font-size:0.95em;">↑ &nbsp;sync</div>
+  <div style="color:#2e86c1;font-size:0.95em;">↑ &nbsp;/rhiza:update</div>
   <div style="background:#eaf4fc;border:2px solid #2e86c1;border-radius:8px;padding:0.7em 2.5em;text-align:center;min-width:52%;">
-    <div style="font-weight:bold;color:#1a5276;">uvx rhiza</div>
-    <div style="font-size:0.82em;color:#555;margin-top:0.2em;">the syncer — runs locally or in CI</div>
+    <div style="font-weight:bold;color:#1a5276;">rhiza-claude</div>
+    <div style="font-size:0.82em;color:#555;margin-top:0.2em;">the interface — <code>/rhiza:*</code> commands you run in Claude Code</div>
   </div>
 </div>
 
@@ -196,7 +196,7 @@ The sync is not a bulldozer. It is a proposal.
 
 ```yaml
 repository: Jebel-Quant/rhiza   # Which template repo to sync from
-ref: v0.19.3                     # Which version (pinned tag — recommended)
+ref: v1.2.0                      # Which version (pinned tag — recommended)
 
 profiles:                         # Curated bundle preset (recommended)
   - github-project
@@ -243,11 +243,10 @@ One file. That's all Rhiza needs.
 
 1. **Fetch** — reads `template.yml`, pulls matching files from the template repo at `ref`
 2. **Diff** — compares what was fetched against what's currently in your project
-3. **Review** — if anything changed, opens a pull request with the diff
+3. **Review** — if anything changed, opens a pull request with the diff (and a quality scorecard)
 4. **Commit** — you review the PR and merge it (or close it if not relevant)
 
-Runs automatically on a **weekly schedule** via GitHub Actions.
-On-demand: `make sync` or `uvx rhiza sync`.
+Run it on demand with **`/rhiza:update`** in Claude Code — it bumps the `ref`, syncs the files, resolves conflicts, and opens the PR.
 
 ---
 
@@ -257,19 +256,19 @@ Without Renovate, the `ref:` pin is frozen. Projects drift behind the template s
 
 <div style="display:flex;flex-direction:column;gap:0.45em;margin:0.9em 0;font-size:0.93em;">
   <div style="background:#eaf4fc;border-left:4px solid #2e86c1;border-radius:0 7px 7px 0;padding:0.6em 1.1em;">
-    template repo publishes <strong>v0.19.3</strong>
+    template repo publishes <strong>v1.2.0</strong>
   </div>
   <div style="padding-left:1.1em;color:#2e86c1;">↓</div>
   <div style="background:#eaf4fc;border-left:4px solid #2e86c1;border-radius:0 7px 7px 0;padding:0.6em 1.1em;">
-    Renovate opens PR: <code>ref: v0.19.2 → v0.19.3</code> &nbsp;<span style="color:#888;">(one line diff)</span>
+    Renovate opens PR: <code>ref: v1.1.0 → v1.2.0</code> &nbsp;<span style="color:#888;">(a notification — one line diff)</span>
   </div>
-  <div style="padding-left:1.1em;color:#2e86c1;">↓ <span style="color:#888;font-size:0.88em;">you merge</span></div>
+  <div style="padding-left:1.1em;color:#2e86c1;">↓ <span style="color:#888;font-size:0.88em;">you run <code>/rhiza:update</code></span></div>
   <div style="background:#eaf4fc;border-left:4px solid #2e86c1;border-radius:0 7px 7px 0;padding:0.6em 1.1em;">
-    sync workflow applies updated CI files, linting config, etc.
+    <code>/rhiza:update</code> applies the new CI files, linting config, etc. in a PR
   </div>
 </div>
 
-Two separate PRs: **should we upgrade?** then **here's what changed.**
+Two separate steps: **should we upgrade?** (the ref-bump PR) then **here's what changed** (the `/rhiza:update` PR).
 Opt-in per repo. Systematic across the organisation.
 
 ---
@@ -287,15 +286,18 @@ Opt-in per repo. Systematic across the organisation.
 # 1. Install uv (skip if already installed)
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# 2. Initialise — writes .rhiza/template.yml interactively
-uvx rhiza init
+# 2. Bootstrap the repo — writes .rhiza/template.yml, first sync, opens a PR
+/rhiza:init
 
-# 3. Sync — fetches template files and writes them into the project
-uvx rhiza sync
+# 3. Pull the latest template — syncs files, resolves conflicts, opens a PR
+/rhiza:update
 
 # 4. Install dev environment
 make install
 ```
+
+The `/rhiza:*` commands come from the rhiza Claude Code plugin — install it once with
+`/plugin marketplace add Jebel-Quant/rhiza-claude` then `/plugin install rhiza@rhiza-claude`.
 
 That's it. Your project is now Rhiza-managed.
 
@@ -306,12 +308,11 @@ That's it. Your project is now Rhiza-managed.
 After syncing with the `github-project` profile (`core + github + tests + github-tests + renovate`):
 
 ```
-.github/workflows/rhiza_ci.yml          ← CI: test on push and PRs
-.github/workflows/rhiza_pre-commit.yml  ← Pre-commit checks in CI
-.github/workflows/rhiza_sync.yml        ← Weekly template sync
-.pre-commit-config.yaml                 ← Local commit hooks
+.github/workflows/rhiza_ci.yml          ← CI: test matrix on push and PRs
+.github/workflows/rhiza_release.yml     ← Build + publish to PyPI on a tag
+.pre-commit-config.yaml                 ← Local commit hooks (rhiza-hooks)
 ruff.toml                               ← Linting config
-Makefile                                ← make test · make lint · make release
+Makefile                                ← make test · make lint
 .python-version                         ← Pinned Python version
 .editorconfig                           ← Editor consistency
 ```
@@ -381,17 +382,15 @@ The PR description usually explains what changed at a high level.
 
 | Tool | What it does |
 |------|-------------|
-| **rhiza-cli** | `uvx rhiza init / sync / validate` — the tool you run |
+| **rhiza-claude** | Claude Code plugin — the `/rhiza:*` command set (`init`, `update`, `quality`, `release`, `revisit`, `stats`, …). The primary interface. |
 | **rhiza-hooks** | Pre-commit hooks: validate config, check version consistency |
-| **rhiza-tools** | `bump`, `release`, `version-matrix`, `coverage-badge` |
-| **rhiza-config** | Claude Code plugin: `/rhiza:boost`, `quality`, `revisit`, `stats` |
 | **rhiza-brainbug** | Cross-repo test harness: runs contract tests on upstream commits |
 
 ---
 
 ## Who's using it
 
-**The Rhiza tools themselves** — rhiza-cli, rhiza-hooks, and rhiza-tools all sync from rhiza. The system eats its own cooking.
+**The Rhiza tools themselves** — rhiza-claude and rhiza-hooks all sync from rhiza. The system eats its own cooking.
 
 **External projects:**
 
@@ -423,7 +422,7 @@ The PR description usually explains what changed at a high level.
 # Get started
 
 ```bash
-uvx rhiza init
+/rhiza:init
 ```
 
 *ῥίζα (ree-ZAH) — root*


### PR DESCRIPTION
## What & why

`rhiza-cli` and `rhiza-tools` were archived (2026-07-16) and `rhiza-config` was renamed to **`rhiza-claude`** — a Claude Code plugin that now drives the whole workflow through `/rhiza:*` commands (no `uvx rhiza` CLI, no automated `rhiza_sync.yml` workflow). This updates the entire curriculum and slide decks to that model.

Versions refreshed to **rhiza v1.2.0 / rhiza-claude v0.4.1**.

## Highlights

- **Lesson 11 (ecosystem)** — core rewrite: `rhiza-cli`/`rhiza-tools`/`rhiza-config` folded into one **rhiza-claude** section (install + full `/rhiza:*` command tables); ecosystem diagram redrawn to center rhiza-claude with `.rhiza/template.lock`; rhiza-hooks + rhiza-brainbug kept.
- **Lessons 08 + 09** — `rhiza_sync.yml` is gone: sync is now `/rhiza:update`, and Renovate's `ref:` bump is a **notification only**. Regex-manager config corrected (`managerFilePatterns` + `github-releases`); the false `rhiza_renovate.yml` claim removed.
- **Lessons 01/02/05/06/07/10** — command mapping applied (`/rhiza:init`, `/rhiza:update`, `/rhiza:release`); `version-matrix`/`coverage-badge` reframed as internal to the reusable CI workflows; `make doctor`→`/rhiza:status`.
- **Lesson 12 / README / index / A2 / A3** — reference tables, curriculum descriptions, and several pre-existing broken cross-links fixed.
- **A1 (GitLab)** — workflow listing corrected to the current `gitlab` bundle (`rhiza_ci`, `rhiza_quality`, `rhiza_book`, `rhiza_release`, `rhiza_renovate`, `rhiza_weekly`); sync/Renovate reframed.
- **3 slide decks + `lessons/slides.md`**, plus **`publish.yml` + `mkdocs.yml`** — footer version stamp now pulls the rhiza-claude GitHub release tag instead of the archived rhiza-cli PyPI version.

## Verification

- Stale-reference sweep clean — only intentional historical notes remain (lesson 11 footnote, A3's historical contribution counts, A1's "there is no `rhiza_sync.yml`" note, lesson 12 CI note).
- `34/34` code-block tests pass; all `json` blocks (Renovate config) also validated.

## Worth a look before merge

- **A3** keeps the real archived-repo contribution counts as historical record (no rhiza-claude counts fabricated) — happy to drop those tables if preferred.
- New mechanics are based on the live `jebel-quant/rhiza` v1.2.0 template + rhiza-claude v0.4.1; the one assumption to sanity-check is that `/rhiza:update` is the intended way users now pull template changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)